### PR TITLE
Deploy installer via kamal nodes

### DIFF
--- a/installer/Dockerfile
+++ b/installer/Dockerfile
@@ -1,4 +1,5 @@
-FROM golang:1.26 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26 AS builder
+ARG TARGETARCH
 
 WORKDIR /app
 
@@ -6,7 +7,7 @@ COPY go.mod ./
 RUN go mod download || true
 
 COPY . .
-RUN CGO_ENABLED=0 go build -trimpath -o installer .
+RUN CGO_ENABLED=0 GOARCH=$TARGETARCH go build -trimpath -o installer .
 
 FROM scratch
 

--- a/installer/config/deploy.yml
+++ b/installer/config/deploy.yml
@@ -2,14 +2,18 @@ service: once-installer
 image: basecamp/once-installer
 
 servers:
-  - 159.65.17.223
+  - once-installer-101
+  - once-installer-102
 
 proxy:
-  host: once.kmcconnell.dev
+  host: get.once.com
   ssl: true
 
 registry:
   server: localhost:5555
+
+ssh:
+  user: app
 
 builder:
   arch: amd64

--- a/installer/config/deploy.yml
+++ b/installer/config/deploy.yml
@@ -7,7 +7,6 @@ servers:
 
 proxy:
   host: get.once.com
-  ssl: true
 
 registry:
   server: localhost:5555


### PR DESCRIPTION
Related to https://3.basecamp.com/2914079/buckets/44030815/todos/9652029302

Point `deploy.yml` at `once-installer-101` and `once-installer-102` in df-iad, use the local registry, and set get.once.com as the proxy host. DNS and SSL will be handled by CloudFlare/F5.