### PR TITLE
Simplify logging setup

### DIFF
--- a/cmd/once/main.go
+++ b/cmd/once/main.go
@@ -4,9 +4,12 @@ import (
 	"os"
 
 	"github.com/basecamp/once/internal/command"
+	"github.com/basecamp/once/internal/logging"
 )
 
 func main() {
+	logging.SetupStderr()
+
 	if err := command.NewRootCommand().Execute(); err != nil {
 		os.Exit(1)
 	}

--- a/internal/command/background_run.go
+++ b/internal/command/background_run.go
@@ -7,7 +7,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/basecamp/once/internal/background"
-	"github.com/basecamp/once/internal/logging"
 )
 
 type backgroundRunCommand struct {
@@ -21,13 +20,7 @@ func newBackgroundRunCommand() *backgroundRunCommand {
 		Short:  "Run background tasks (automatic backups and updates)",
 		Args:   cobra.NoArgs,
 		Hidden: true,
-
-		// Note: override parent PersistentPreRunE here, so we skip the default logging setup.
-		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			logging.SetupStderr()
-			return nil
-		},
-		RunE: b.run,
+		RunE:   b.run,
 	}
 	return b
 }

--- a/internal/command/root.go
+++ b/internal/command/root.go
@@ -12,9 +12,8 @@ import (
 )
 
 type RootCommand struct {
-	cmd         *cobra.Command
-	namespace   string
-	closeLogger func()
+	cmd       *cobra.Command
+	namespace string
 
 	installImageRef string
 }
@@ -28,21 +27,10 @@ func NewRootCommand() *RootCommand {
 		CompletionOptions: cobra.CompletionOptions{
 			HiddenDefaultCmd: true,
 		},
-		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			closeLogger, err := logging.SetupFile()
-			if err != nil {
-				return fmt.Errorf("setting up logging: %w", err)
-			}
-			r.closeLogger = closeLogger
-			return nil
-		},
-		PersistentPostRun: func(cmd *cobra.Command, args []string) {
-			if r.closeLogger != nil {
-				r.closeLogger()
-			}
-		},
 		RunE: WithNamespace(func(ctx context.Context, ns *docker.Namespace, cmd *cobra.Command, args []string) error {
-			return ui.Run(ns, r.installImageRef)
+			return logging.ToLogFile(func() error {
+				return ui.Run(ns, r.installImageRef)
+			})
 		}),
 	}
 	r.cmd.PersistentFlags().StringVarP(&r.namespace, "namespace", "n", docker.DefaultNamespace, "namespace for containers")

--- a/internal/docker/application_backup.go
+++ b/internal/docker/application_backup.go
@@ -12,12 +12,13 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"syscall"
 	"time"
 
 	"github.com/containerd/errdefs"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/mount"
+
+	"github.com/basecamp/once/internal/fsutil"
 )
 
 const (
@@ -42,24 +43,20 @@ func (a *Application) BackupName() string {
 }
 
 func (a *Application) BackupToFile(ctx context.Context, dir string, name string) error {
-	uid, gid, err := prepareBackupDir(dir)
-	if err != nil {
-		slog.Error("Failed to create backup directory", "app", a.Settings.Name, "directory", dir, "error", err)
-		return err
+	if dir == "" {
+		return fmt.Errorf("backup location is required")
+	}
+	if !filepath.IsAbs(dir) {
+		return ErrBackupPathRelative
 	}
 
 	filePath := filepath.Join(dir, name)
-	file, err := os.Create(filePath)
+	file, err := fsutil.CreateFile(filePath)
 	if err != nil {
 		slog.Error("Failed to create backup file", "app", a.Settings.Name, "filename", filePath, "error", err)
 		return fmt.Errorf("creating backup file: %w", err)
 	}
 	defer file.Close()
-
-	if err := os.Chown(filePath, uid, gid); err != nil {
-		slog.Error("Failed to set backup file ownership", "app", a.Settings.Name, "filename", filePath, "error", err)
-		return fmt.Errorf("setting backup file ownership: %w", err)
-	}
 
 	err = a.backupToWriter(ctx, file)
 	a.saveOperationResult(ctx, func(s *State) { s.RecordBackup(a.Settings.Name, err) })
@@ -331,74 +328,6 @@ func (a *Application) tryHookScript(ctx context.Context, containerName, name str
 }
 
 // Helpers
-
-func prepareBackupDir(dir string) (int, int, error) {
-	if dir == "" {
-		return 0, 0, fmt.Errorf("backup location is required")
-	}
-
-	if !filepath.IsAbs(dir) {
-		return 0, 0, ErrBackupPathRelative
-	}
-
-	uid, gid, err := findOwnership(dir)
-	if err != nil {
-		return 0, 0, fmt.Errorf("determining backup directory ownership: %w", err)
-	}
-
-	if err := os.MkdirAll(dir, 0o755); err != nil {
-		return 0, 0, fmt.Errorf("creating backup directory: %w", err)
-	}
-
-	if err := chownNewDirs(dir, uid, gid); err != nil {
-		return 0, 0, fmt.Errorf("setting backup directory ownership: %w", err)
-	}
-
-	return uid, gid, nil
-}
-
-func findOwnership(dir string) (int, int, error) {
-	for path := dir; ; path = filepath.Dir(path) {
-		info, err := os.Stat(path)
-		if err == nil {
-			stat := info.Sys().(*syscall.Stat_t)
-			return int(stat.Uid), int(stat.Gid), nil
-		}
-		if !os.IsNotExist(err) {
-			return 0, 0, err
-		}
-		if path == "/" {
-			return 0, 0, fmt.Errorf("no existing parent directory found for %s", dir)
-		}
-	}
-}
-
-func chownNewDirs(dir string, uid, gid int) error {
-	// Collect dirs from deepest to shallowest, stopping at the first
-	// one that already has the correct ownership.
-	var dirs []string
-	for path := dir; ; path = filepath.Dir(path) {
-		info, err := os.Stat(path)
-		if err != nil {
-			break
-		}
-		stat := info.Sys().(*syscall.Stat_t)
-		if int(stat.Uid) == uid && int(stat.Gid) == gid {
-			break
-		}
-		dirs = append(dirs, path)
-		if path == "/" {
-			break
-		}
-	}
-
-	for _, d := range dirs {
-		if err := os.Chown(d, uid, gid); err != nil {
-			return err
-		}
-	}
-	return nil
-}
 
 func parseBackupTime(appName, filename string) (time.Time, bool) {
 	prefix := appName + "-"

--- a/internal/docker/application_backup_test.go
+++ b/internal/docker/application_backup_test.go
@@ -28,17 +28,6 @@ func TestBackupToFile_RelativePath(t *testing.T) {
 	require.ErrorIs(t, err, ErrBackupPathRelative)
 }
 
-func TestBackupToFile_CreatesDirectory(t *testing.T) {
-	dir := filepath.Join(t.TempDir(), "nested", "backup", "dir")
-
-	_, _, err := prepareBackupDir(dir)
-	require.NoError(t, err)
-
-	info, err := os.Stat(dir)
-	require.NoError(t, err)
-	assert.True(t, info.IsDir())
-}
-
 func TestBackup_EmptyPath(t *testing.T) {
 	app := &Application{Settings: ApplicationSettings{Name: "chat"}}
 	err := app.Backup(context.Background())

--- a/internal/fsutil/fsutil.go
+++ b/internal/fsutil/fsutil.go
@@ -1,0 +1,88 @@
+package fsutil
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"syscall"
+)
+
+// OpenFile behaves like os.OpenFile, except that:
+//  1. Any missing parent directories in the path are created implicitly
+//  2. Ownership of the file (and any created parent directories) are set to
+//     match that of the nearest existing ancestor.
+func OpenFile(path string, flag int, perm os.FileMode) (*os.File, error) {
+	dir := filepath.Dir(path)
+
+	uid, gid, err := findOwnership(dir)
+	if err != nil {
+		return nil, fmt.Errorf("determining ownership for %s: %w", dir, err)
+	}
+
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return nil, fmt.Errorf("creating directory %s: %w", dir, err)
+	}
+
+	if err := chownNewDirs(dir, uid, gid); err != nil {
+		return nil, fmt.Errorf("setting directory ownership for %s: %w", dir, err)
+	}
+
+	file, err := os.OpenFile(path, flag, perm)
+	if err != nil {
+		return nil, err
+	}
+
+	_ = os.Chown(path, uid, gid)
+
+	return file, nil
+}
+
+// CreateFile creates a new file, truncating it if it already exists. It is
+// equivalent to OpenFile with O_RDWR|O_CREATE|O_TRUNC flags and 0600
+// permissions (owner read/write only).
+func CreateFile(path string) (*os.File, error) {
+	return OpenFile(path, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0o600)
+}
+
+// Helpers
+
+func findOwnership(dir string) (int, int, error) {
+	for path := dir; ; path = filepath.Dir(path) {
+		info, err := os.Stat(path)
+		if err == nil {
+			stat := info.Sys().(*syscall.Stat_t)
+			return int(stat.Uid), int(stat.Gid), nil
+		}
+		if !os.IsNotExist(err) {
+			return 0, 0, err
+		}
+		if path == "/" {
+			return 0, 0, fmt.Errorf("no existing parent directory found for %s", dir)
+		}
+	}
+}
+
+func chownNewDirs(dir string, uid, gid int) error {
+	var dirs []string
+	for path := dir; ; path = filepath.Dir(path) {
+		info, err := os.Stat(path)
+		if err != nil {
+			break
+		}
+		stat := info.Sys().(*syscall.Stat_t)
+		if int(stat.Uid) == uid && int(stat.Gid) == gid {
+			break
+		}
+		dirs = append(dirs, path)
+		if path == "/" {
+			break
+		}
+	}
+
+	for _, d := range dirs {
+		if err := os.Chown(d, uid, gid); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/internal/fsutil/fsutil_test.go
+++ b/internal/fsutil/fsutil_test.go
@@ -1,0 +1,93 @@
+package fsutil
+
+import (
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOpenFile_CreatesParentDirs(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "a", "b", "file.txt")
+
+	f, err := OpenFile(path, os.O_CREATE|os.O_WRONLY, 0o644)
+	require.NoError(t, err)
+	f.Close()
+
+	assertOwnership(t, filepath.Dir(path))
+	assertOwnership(t, path)
+}
+
+func TestOpenFile_ExistingDir(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "file.txt")
+
+	f, err := OpenFile(path, os.O_CREATE|os.O_WRONLY, 0o644)
+	require.NoError(t, err)
+	f.Close()
+
+	assertOwnership(t, path)
+}
+
+func TestOpenFile_AppendsToExisting(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "file.txt")
+	require.NoError(t, os.WriteFile(path, []byte("hello"), 0o644))
+
+	f, err := OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	require.NoError(t, err)
+	f.Write([]byte(" world"))
+	f.Close()
+
+	content, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, "hello world", string(content))
+}
+
+func TestCreateFile_TruncatesExisting(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "file.txt")
+	require.NoError(t, os.WriteFile(path, []byte("old content"), 0o644))
+
+	f, err := CreateFile(path)
+	require.NoError(t, err)
+	f.Write([]byte("new"))
+	f.Close()
+
+	content, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, "new", string(content))
+}
+
+func TestCreateFile_NewFilePermissions(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "file.txt")
+
+	f, err := CreateFile(path)
+	require.NoError(t, err)
+	f.Close()
+
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o600), info.Mode().Perm())
+}
+
+func TestOpenFile_UnwritableParent(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "blocked")
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	require.NoError(t, os.Chmod(dir, 0o000))
+	t.Cleanup(func() { os.Chmod(dir, 0o755) })
+
+	_, err := OpenFile(filepath.Join(dir, "sub", "file.txt"), os.O_CREATE|os.O_WRONLY, 0o644)
+	require.Error(t, err)
+}
+
+// Helpers
+
+func assertOwnership(t *testing.T, path string) {
+	t.Helper()
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	stat := info.Sys().(*syscall.Stat_t)
+	assert.Equal(t, os.Getuid(), int(stat.Uid))
+	assert.Equal(t, os.Getgid(), int(stat.Gid))
+}

--- a/internal/logging/log.go
+++ b/internal/logging/log.go
@@ -1,31 +1,37 @@
 package logging
 
 import (
-	"fmt"
 	"log/slog"
 	"os"
 	"path/filepath"
+
+	"github.com/basecamp/once/internal/fsutil"
 )
 
-func SetupFile() (func(), error) {
+// ToLogFile switches logging to a file for the duration of fn, then restores
+// stderr logging when fn returns.
+func ToLogFile(fn func() error) error {
 	dir, err := stateDir()
 	if err != nil {
-		return nil, fmt.Errorf("determining log directory: %w", err)
-	}
-
-	if err := os.MkdirAll(dir, 0o755); err != nil {
-		return nil, fmt.Errorf("creating log directory: %w", err)
+		slog.Warn("Could not determine log directory", "error", err)
+		return fn()
 	}
 
 	path := filepath.Join(dir, "once.log")
-	file, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	file, err := fsutil.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
 	if err != nil {
-		return nil, fmt.Errorf("opening log file: %w", err)
+		slog.Warn("Could not open log file", "error", err)
+		return fn()
 	}
+
+	defer func() {
+		SetupStderr()
+		file.Close()
+	}()
 
 	slog.SetDefault(slog.New(slog.NewTextHandler(file, nil)))
 
-	return func() { file.Close() }, nil
+	return fn()
 }
 
 func SetupStderr() {


### PR DESCRIPTION
- Ensure file logs are created with user ownership, even when run under sudo
- Extract ownership handling when creating files & containing directories
- Only TUI should log to file; all CLI commands log to stderr