### PR TITLE
Simplify color detection

### DIFF
--- a/internal/ui/palette_detect.go
+++ b/internal/ui/palette_detect.go
@@ -108,9 +108,6 @@ func detectFrom(rw io.ReadWriter, timeout time.Duration) DetectedColors {
 		select {
 		case r := <-ch:
 			collect(r)
-			if received >= sampleCount {
-				return detected
-			}
 		case <-done:
 			// Drain any remaining buffered results
 			for {

--- a/internal/ui/palette_detect.go
+++ b/internal/ui/palette_detect.go
@@ -1,12 +1,14 @@
 package ui
 
 import (
+	"bufio"
 	"fmt"
 	"io"
 	"os"
 	"slices"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/charmbracelet/x/term"
@@ -25,8 +27,6 @@ type DetectedColors struct {
 	Detected [sampleCount]bool
 }
 
-// SupportsTrueColor returns true if the terminal responded with RGB color
-// values, implying it can also render them.
 // SupportsTrueColor reports whether the terminal is likely to support
 // 24-bit color output. COLORTERM is the authoritative signal; when it is
 // absent (common over SSH), we infer support from successful OSC palette
@@ -40,15 +40,10 @@ func (d DetectedColors) SupportsTrueColor() bool {
 	return slices.Contains(d.Detected[:], true)
 }
 
-type colorResult struct {
-	index int
-	color colorful.Color
-}
-
 // DetectTerminalColors queries the terminal for foreground, background,
 // and all 16 ANSI palette colors via OSC sequences. A DA1 request is
-// appended as a sentinel. The function returns after all responses arrive,
-// the DA1 sentinel is received, or the timeout expires.
+// appended as a sentinel. The function returns after the DA1 sentinel
+// is received or the timeout expires.
 func DetectTerminalColors(timeout time.Duration) DetectedColors {
 	tty, err := os.OpenFile("/dev/tty", os.O_RDWR, 0)
 	if err != nil {
@@ -62,188 +57,135 @@ func DetectTerminalColors(timeout time.Duration) DetectedColors {
 		return DetectedColors{}
 	}
 
-	defer func() {
+	cleanup := sync.OnceFunc(func() {
 		term.Restore(fd, oldState)
 		tty.Close()
-	}()
+	})
+	defer cleanup()
 
-	return detectFrom(tty, timeout)
+	time.AfterFunc(timeout, cleanup)
+
+	return detectFrom(tty)
 }
 
 // detectFrom runs the OSC query/response cycle over any ReadWriter.
-// It spawns a reader goroutine that blocks on rw.Read; the caller must
-// close rw after detectFrom returns to unblock the goroutine.
-// Split out from DetectTerminalColors for testability.
-func detectFrom(rw io.ReadWriter, timeout time.Duration) DetectedColors {
+// It reads responses until DA1 is seen or a read error occurs. The
+// caller can close the reader to interrupt.
+func detectFrom(rw io.ReadWriter) DetectedColors {
 	var query strings.Builder
-	query.WriteString("\x1b]10;?\x07") // foreground
-	query.WriteString("\x1b]11;?\x07") // background
+	oscQuery := func(code string) { fmt.Fprintf(&query, "\x1b]%s;?\x07", code) }
+	csiQuery := func(code string) { fmt.Fprintf(&query, "\x1b[%s", code) }
+
+	oscQuery("10") // foreground
+	oscQuery("11") // background
 	for i := range 16 {
-		fmt.Fprintf(&query, "\x1b]4;%d;?\x07", i)
+		oscQuery(fmt.Sprintf("4;%d", i))
 	}
-	query.WriteString("\x1b[c") // DA1 sentinel
+	csiQuery("c") // DA1 sentinel
 
 	if _, err := rw.Write([]byte(query.String())); err != nil {
 		return DetectedColors{}
 	}
 
-	ch := make(chan colorResult, sampleCount)
-	done := make(chan struct{})
-
-	go readOSCResponses(rw, ch, done)
-
-	var detected DetectedColors
-	timer := time.After(timeout)
-	received := 0
-
-	collect := func(r colorResult) {
-		if r.index >= 0 && r.index < sampleCount {
-			detected.Colors[r.index] = r.color
-			detected.Detected[r.index] = true
-			received++
-		}
-	}
-
+	d := detector{reader: bufio.NewReader(rw)}
 	for {
-		select {
-		case r := <-ch:
-			collect(r)
-		case <-done:
-			// Drain any remaining buffered results
-			for {
-				select {
-				case r := <-ch:
-					collect(r)
-				default:
-					return detected
-				}
-			}
-		case <-timer:
-			// Drain any results already buffered
-			for {
-				select {
-				case r := <-ch:
-					collect(r)
-				default:
-					return detected
-				}
-			}
+		da1, err := d.readNext()
+		if da1 || err != nil {
+			return d.colors
 		}
 	}
 }
 
-// readOSCResponses reads from the reader, parses OSC color responses,
-// and sends them to ch. Closes done when DA1 is seen or a read error occurs.
-func readOSCResponses(r io.Reader, ch chan<- colorResult, done chan<- struct{}) {
-	defer close(done)
+// Private
 
-	buf := make([]byte, 4096)
-	var acc []byte
+type detector struct {
+	colors DetectedColors
+	reader *bufio.Reader
+}
 
+// readNext scans for the next escape sequence and dispatches to the
+// appropriate reader. Returns true when DA1 is seen.
+func (d *detector) readNext() (da1 bool, err error) {
 	for {
-		n, err := r.Read(buf)
-		if n > 0 {
-			acc = append(acc, buf[:n]...)
-			var da1 bool
-			acc, da1 = processBuffer(acc, ch)
-			if da1 {
-				return
-			}
-		}
+		b, err := d.reader.ReadByte()
 		if err != nil {
-			return
+			return false, err
 		}
-	}
-}
-
-// processBuffer extracts complete OSC responses and DA1 from the
-// accumulated buffer. Returns the unprocessed remainder and whether
-// DA1 was seen.
-func processBuffer(buf []byte, ch chan<- colorResult) ([]byte, bool) {
-	for {
-		// Look for DA1 response: CSI ... c
-		if i := findDA1(buf); i >= 0 {
-			processOSCSequences(buf[:i], ch)
-			return nil, true
+		if b != 0x1b {
+			continue
 		}
 
-		// Look for a complete OSC response terminated by BEL or ST
-		end := findOSCEnd(buf)
-		if end < 0 {
-			return buf, false
+		b, err = d.reader.ReadByte()
+		if err != nil {
+			return false, err
 		}
 
-		seq := buf[:end]
-		buf = buf[end:]
-		parseOSCColor(seq, ch)
-	}
-}
-
-// findDA1 finds a DA1 response (ESC [ ... c) in the buffer.
-func findDA1(buf []byte) int {
-	for i := range len(buf) - 2 {
-		if buf[i] == 0x1b && buf[i+1] == '[' {
-			for j := i + 2; j < len(buf); j++ {
-				if buf[j] == 'c' {
-					return i
-				}
-				if buf[j] >= 0x40 && buf[j] <= 0x7e {
-					break // different CSI final byte
-				}
+		switch b {
+		case ']':
+			if err := d.readOSC(); err != nil {
+				return false, err
 			}
+			return false, nil
+		case '[':
+			return d.readCSI()
 		}
-	}
-	return -1
-}
-
-// findOSCEnd finds the end of the first OSC sequence in buf.
-// Returns the index after the terminator, or -1 if incomplete.
-func findOSCEnd(buf []byte) int {
-	for i := range len(buf) {
-		if buf[i] == 0x07 { // BEL
-			return i + 1
-		}
-		if buf[i] == 0x1b && i+1 < len(buf) && buf[i+1] == '\\' { // ST
-			return i + 2
-		}
-	}
-	return -1
-}
-
-func processOSCSequences(buf []byte, ch chan<- colorResult) {
-	for len(buf) > 0 {
-		end := findOSCEnd(buf)
-		if end < 0 {
-			return
-		}
-		parseOSCColor(buf[:end], ch)
-		buf = buf[end:]
 	}
 }
 
-// parseOSCColor parses an OSC color response and sends the result.
-// Formats:
-//
-//	ESC ] 10 ; rgb:RRRR/GGGG/BBBB BEL  (foreground)
-//	ESC ] 11 ; rgb:RRRR/GGGG/BBBB BEL  (background)
-//	ESC ] 4 ; N ; rgb:RRRR/GGGG/BBBB BEL  (ANSI color N)
-func parseOSCColor(seq []byte, ch chan<- colorResult) {
-	s := string(seq)
-
-	if !strings.HasPrefix(s, "\x1b]") {
-		return
+// readOSC reads an OSC sequence body (after ESC ]) until the BEL or
+// ST terminator, then stores any color result.
+func (d *detector) readOSC() error {
+	var body []byte
+	for {
+		b, err := d.reader.ReadByte()
+		if err != nil {
+			return err
+		}
+		switch b {
+		case 0x07: // BEL
+			d.collectColor(body)
+			return nil
+		case 0x1b: // possible ST
+			next, err := d.reader.ReadByte()
+			if err != nil {
+				return err
+			}
+			if next == '\\' {
+				d.collectColor(body)
+				return nil
+			}
+			body = append(body, b, next)
+		default:
+			body = append(body, b)
+		}
 	}
-	s = s[2:]
+}
 
-	// Strip terminator
-	s = strings.TrimRight(s, "\x07")
-	s = strings.TrimSuffix(s, "\x1b\\")
+// readCSI reads a CSI sequence (after ESC [) until a final byte.
+// Returns true if the final byte is 'c' (DA1).
+func (d *detector) readCSI() (da1 bool, err error) {
+	for {
+		b, err := d.reader.ReadByte()
+		if err != nil {
+			return false, err
+		}
+		if b >= 0x40 && b <= 0x7e {
+			return b == 'c', nil
+		}
+	}
+}
+
+// collectColor parses an OSC color response body and stores the result.
+// The body is the content between ESC ] and the terminator, e.g.
+// "10;rgb:c0c0/caca/f5f5" or "4;2;rgb:5050/fafa/7b7b".
+func (d *detector) collectColor(body []byte) {
+	s := string(body)
 
 	rgbIdx := strings.Index(s, "rgb:")
 	if rgbIdx < 0 {
 		return
 	}
-	prefix := s[:rgbIdx]
+	prefix := strings.TrimRight(s[:rgbIdx], ";")
 	rgbStr := s[rgbIdx:]
 
 	clr, ok := parseRGB(rgbStr)
@@ -251,23 +193,29 @@ func parseOSCColor(seq []byte, ch chan<- colorResult) {
 		return
 	}
 
-	prefix = strings.TrimRight(prefix, ";")
+	index := -1
 	switch {
 	case prefix == "10":
-		ch <- colorResult{sampleForeground, clr}
+		index = sampleForeground
 	case prefix == "11":
-		ch <- colorResult{sampleBackground, clr}
+		index = sampleBackground
 	case strings.HasPrefix(prefix, "4;"):
-		numStr := strings.TrimPrefix(prefix, "4;")
-		n, err := strconv.Atoi(numStr)
+		n, err := strconv.Atoi(strings.TrimPrefix(prefix, "4;"))
 		if err == nil && n >= 0 && n < 16 {
-			ch <- colorResult{n, clr}
+			index = n
 		}
+	}
+
+	if index >= 0 {
+		d.colors.Colors[index] = clr
+		d.colors.Detected[index] = true
 	}
 }
 
+// Helpers
+
 // parseRGB parses "rgb:RRRR/GGGG/BBBB" into a colorful.Color.
-// Handles both 4-digit (16-bit) and 2-digit (8-bit) hex components.
+// Handles 1 to 4 hex digits per component (XParseColor format).
 func parseRGB(s string) (colorful.Color, bool) {
 	s = strings.TrimPrefix(s, "rgb:")
 	parts := strings.Split(s, "/")
@@ -275,8 +223,6 @@ func parseRGB(s string) (colorful.Color, bool) {
 		return colorful.Color{}, false
 	}
 
-	// XParseColor allows 1-4 hex digits per component: h, hh, hhh, hhhh.
-	// Each is scaled to its own range: h/0xF, hh/0xFF, hhh/0xFFF, hhhh/0xFFFF.
 	parse := func(hex string) (float64, bool) {
 		if len(hex) < 1 || len(hex) > 4 {
 			return 0, false

--- a/internal/ui/palette_detect_test.go
+++ b/internal/ui/palette_detect_test.go
@@ -1,8 +1,10 @@
 package ui
 
 import (
+	"bufio"
 	"bytes"
 	"io"
+	"strings"
 	"testing"
 	"time"
 
@@ -54,95 +56,69 @@ func TestParseRGBInvalid(t *testing.T) {
 	assert.False(t, ok)
 }
 
-func TestParseOSCForeground(t *testing.T) {
-	ch := make(chan colorResult, 1)
-	parseOSCColor([]byte("\x1b]10;rgb:c0c0/caca/f5f5\x07"), ch)
-	require.Len(t, ch, 1)
-	r := <-ch
-	assert.Equal(t, sampleForeground, r.index)
-	assert.InDelta(t, 0.753, r.color.R, 0.01)
+func newTestDetector(data string) *detector {
+	return &detector{reader: bufio.NewReader(strings.NewReader(data))}
 }
 
-func TestParseOSCBackground(t *testing.T) {
-	ch := make(chan colorResult, 1)
-	parseOSCColor([]byte("\x1b]11;rgb:1a1a/1b1b/2626\x07"), ch)
-	require.Len(t, ch, 1)
-	r := <-ch
-	assert.Equal(t, sampleBackground, r.index)
-	assert.InDelta(t, 0.102, r.color.R, 0.01)
-}
-
-func TestParseOSCANSIColor(t *testing.T) {
-	ch := make(chan colorResult, 1)
-	parseOSCColor([]byte("\x1b]4;4;rgb:7a7a/a2a2/f7f7\x07"), ch)
-	require.Len(t, ch, 1)
-	r := <-ch
-	assert.Equal(t, 4, r.index) // blue
-	assert.InDelta(t, 0.478, r.color.R, 0.01)
-}
-
-func TestParseOSCWithST(t *testing.T) {
-	ch := make(chan colorResult, 1)
-	parseOSCColor([]byte("\x1b]10;rgb:ffff/ffff/ffff\x1b\\"), ch)
-	require.Len(t, ch, 1)
-	r := <-ch
-	assert.Equal(t, sampleForeground, r.index)
-	assert.InDelta(t, 1.0, r.color.R, 0.001)
-}
-
-func TestProcessBufferDA1(t *testing.T) {
-	ch := make(chan colorResult, sampleCount)
-
-	// Buffer with one OSC response followed by DA1
-	buf := []byte("\x1b]10;rgb:ffff/ffff/ffff\x07\x1b[?62;c")
-	remainder, da1 := processBuffer(buf, ch)
-	assert.True(t, da1)
-	assert.Nil(t, remainder)
-	assert.Len(t, ch, 1)
-}
-
-func TestProcessBufferNoDA1(t *testing.T) {
-	ch := make(chan colorResult, sampleCount)
-
-	buf := []byte("\x1b]10;rgb:ffff/ffff/ffff\x07")
-	remainder, da1 := processBuffer(buf, ch)
+func TestReadForegroundColor(t *testing.T) {
+	d := newTestDetector("\x1b]10;rgb:c0c0/caca/f5f5\x07")
+	da1, err := d.readNext()
+	require.NoError(t, err)
 	assert.False(t, da1)
-	assert.Empty(t, remainder)
-	assert.Len(t, ch, 1)
+	assert.True(t, d.colors.Detected[sampleForeground])
+	assert.InDelta(t, 0.753, d.colors.Colors[sampleForeground].R, 0.01)
 }
 
-func TestProcessBufferMultipleResponses(t *testing.T) {
-	ch := make(chan colorResult, sampleCount)
+func TestReadBackgroundColor(t *testing.T) {
+	d := newTestDetector("\x1b]11;rgb:1a1a/1b1b/2626\x07")
+	da1, err := d.readNext()
+	require.NoError(t, err)
+	assert.False(t, da1)
+	assert.True(t, d.colors.Detected[sampleBackground])
+	assert.InDelta(t, 0.102, d.colors.Colors[sampleBackground].R, 0.01)
+}
 
-	buf := []byte(
+func TestReadANSIColor(t *testing.T) {
+	d := newTestDetector("\x1b]4;4;rgb:7a7a/a2a2/f7f7\x07")
+	da1, err := d.readNext()
+	require.NoError(t, err)
+	assert.False(t, da1)
+	assert.True(t, d.colors.Detected[4]) // blue
+	assert.InDelta(t, 0.478, d.colors.Colors[4].R, 0.01)
+}
+
+func TestReadColorWithSTTerminator(t *testing.T) {
+	d := newTestDetector("\x1b]10;rgb:ffff/ffff/ffff\x1b\\")
+	da1, err := d.readNext()
+	require.NoError(t, err)
+	assert.False(t, da1)
+	assert.True(t, d.colors.Detected[sampleForeground])
+	assert.InDelta(t, 1.0, d.colors.Colors[sampleForeground].R, 0.001)
+}
+
+func TestReadDA1(t *testing.T) {
+	d := newTestDetector("\x1b[?62;c")
+	da1, err := d.readNext()
+	require.NoError(t, err)
+	assert.True(t, da1)
+}
+
+func TestReadMultipleResponses(t *testing.T) {
+	d := newTestDetector(
 		"\x1b]10;rgb:c0c0/caca/f5f5\x07" +
 			"\x1b]11;rgb:1a1a/1b1b/2626\x07" +
 			"\x1b]4;2;rgb:5050/fafa/7b7b\x07",
 	)
-	remainder, da1 := processBuffer(buf, ch)
-	assert.False(t, da1)
-	assert.Empty(t, remainder)
-	assert.Len(t, ch, 3)
 
-	r := <-ch
-	assert.Equal(t, sampleForeground, r.index)
-	r = <-ch
-	assert.Equal(t, sampleBackground, r.index)
-	r = <-ch
-	assert.Equal(t, 2, r.index)
-}
+	for range 3 {
+		da1, err := d.readNext()
+		require.NoError(t, err)
+		assert.False(t, da1)
+	}
 
-func TestFindDA1(t *testing.T) {
-	assert.Equal(t, 5, findDA1([]byte("hello\x1b[?62;22c")))
-	assert.Equal(t, -1, findDA1([]byte("hello\x1b[?62;22m"))) // wrong final byte
-	assert.Equal(t, 0, findDA1([]byte("\x1b[c")))
-	assert.Equal(t, -1, findDA1([]byte("no da1 here")))
-}
-
-func TestFindOSCEnd(t *testing.T) {
-	assert.Equal(t, 5, findOSCEnd([]byte("test\x07rest")))
-	assert.Equal(t, 6, findOSCEnd([]byte("test\x1b\\rest")))
-	assert.Equal(t, -1, findOSCEnd([]byte("incomplete")))
+	assert.True(t, d.colors.Detected[sampleForeground])
+	assert.True(t, d.colors.Detected[sampleBackground])
+	assert.True(t, d.colors.Detected[2])
 }
 
 func TestDetectedColorsDefaultEmpty(t *testing.T) {
@@ -182,7 +158,7 @@ func TestDetectFromDarkTheme(t *testing.T) {
 		"\x1b[?62;22c" // DA1 sentinel
 
 	mock := newMockTTY([]byte(response))
-	d := detectFrom(mock, time.Second)
+	d := detectFrom(mock)
 
 	assert.True(t, d.Detected[sampleForeground])
 	assert.True(t, d.Detected[sampleBackground])
@@ -203,7 +179,7 @@ func TestDetectFromLightTheme(t *testing.T) {
 		"\x1b[?62;c" // DA1
 
 	mock := newMockTTY([]byte(response))
-	d := detectFrom(mock, time.Second)
+	d := detectFrom(mock)
 
 	assert.True(t, d.Detected[sampleForeground])
 	assert.True(t, d.Detected[sampleBackground])
@@ -225,7 +201,7 @@ func TestDetectFromPartialResponse(t *testing.T) {
 		"\x1b[?62;c"
 
 	mock := newMockTTY([]byte(response))
-	d := detectFrom(mock, time.Second)
+	d := detectFrom(mock)
 
 	assert.True(t, d.Detected[sampleBackground])
 	assert.False(t, d.Detected[sampleForeground])
@@ -236,7 +212,7 @@ func TestDetectFromNoOSCSupport(t *testing.T) {
 	// Terminal that doesn't support OSC queries — reader returns EOF
 	// immediately (no response data at all).
 	mock := newMockTTY([]byte{})
-	d := detectFrom(mock, 50*time.Millisecond)
+	d := detectFrom(mock)
 
 	for i := range sampleCount {
 		assert.False(t, d.Detected[i])
@@ -251,7 +227,8 @@ func TestDetectFromTimeout(t *testing.T) {
 	rw := &mockTTY{Reader: pr, Writer: io.Discard}
 
 	start := time.Now()
-	d := detectFrom(rw, 50*time.Millisecond)
+	time.AfterFunc(50*time.Millisecond, func() { pr.Close() })
+	d := detectFrom(rw)
 	elapsed := time.Since(start)
 
 	for i := range sampleCount {


### PR DESCRIPTION
When detecting terminal colors at startup:
- Ensure we consume the sentinel marker, so as not to leak it back to the terminal on exit
- Simplify the logic for processing the response: we can just read and parse the incoming buffer until we get the sentinel, and close the reader on timeout