### PR TITLE
Allow updating a specific app via `once update <app>`

### DIFF
--- a/internal/command/deploy.go
+++ b/internal/command/deploy.go
@@ -58,18 +58,7 @@ func (d *deployCommand) run(ctx context.Context, ns *docker.Namespace, cmd *cobr
 		AutoUpdate: true,
 	})
 
-	progress := func(p docker.DeployProgress) {
-		switch p.Stage {
-		case docker.DeployStageDownloading:
-			fmt.Printf("Downloading: %d%%\n", p.Percentage)
-		case docker.DeployStageStarting:
-			fmt.Println("Starting...")
-		case docker.DeployStageFinished:
-			fmt.Println("Finished")
-		}
-	}
-
-	if err := app.Deploy(ctx, progress); err != nil {
+	if err := app.Deploy(ctx, printDeployProgress); err != nil {
 		if cleanupErr := app.Destroy(context.Background(), true); cleanupErr != nil {
 			slog.Error("Failed to clean up after deploy failure", "app", name, "error", cleanupErr)
 		}

--- a/internal/command/root.go
+++ b/internal/command/root.go
@@ -90,3 +90,14 @@ func namespaceFlag(cmd *cobra.Command) string {
 	namespace, _ := cmd.Root().PersistentFlags().GetString("namespace")
 	return namespace
 }
+
+func printDeployProgress(p docker.DeployProgress) {
+	switch p.Stage {
+	case docker.DeployStageDownloading:
+		fmt.Printf("Downloading: %d%%\n", p.Percentage)
+	case docker.DeployStageStarting:
+		fmt.Println("Starting...")
+	case docker.DeployStageFinished:
+		fmt.Println("Finished")
+	}
+}

--- a/internal/command/update.go
+++ b/internal/command/update.go
@@ -1,8 +1,12 @@
 package command
 
 import (
+	"context"
+	"fmt"
+
 	"github.com/spf13/cobra"
 
+	"github.com/basecamp/once/internal/docker"
 	"github.com/basecamp/once/internal/version"
 )
 
@@ -13,12 +17,47 @@ type updateCommand struct {
 func newUpdateCommand() *updateCommand {
 	u := &updateCommand{}
 	u.cmd = &cobra.Command{
-		Use:   "update",
-		Short: "Update once to the latest version",
-		Args:  cobra.NoArgs,
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return version.NewUpdater().UpdateBinary()
-		},
+		Use:   "update [app]",
+		Short: "Update once to the latest version, or update a specific application",
+		Args:  cobra.MaximumNArgs(1),
+		RunE:  WithNamespace(u.run),
 	}
 	return u
+}
+
+// Private
+
+func (u *updateCommand) run(ctx context.Context, ns *docker.Namespace, cmd *cobra.Command, args []string) error {
+	if len(args) == 0 {
+		return version.NewUpdater().UpdateBinary()
+	}
+
+	appName := args[0]
+	progress := func(p docker.DeployProgress) {
+		switch p.Stage {
+		case docker.DeployStageDownloading:
+			fmt.Printf("Downloading: %d%%\n", p.Percentage)
+		case docker.DeployStageStarting:
+			fmt.Println("Starting...")
+		case docker.DeployStageFinished:
+			fmt.Println("Finished")
+		}
+	}
+
+	var changed bool
+	err := withApplication(ns, appName, "updating", func(app *docker.Application) error {
+		var err error
+		changed, err = app.Update(ctx, progress)
+		return err
+	})
+	if err != nil {
+		return err
+	}
+
+	if changed {
+		fmt.Printf("Updated %s\n", appName)
+	} else {
+		fmt.Printf("%s is already up to date\n", appName)
+	}
+	return nil
 }

--- a/internal/command/update.go
+++ b/internal/command/update.go
@@ -20,7 +20,12 @@ func newUpdateCommand() *updateCommand {
 		Use:   "update [app]",
 		Short: "Update once to the latest version, or update a specific application",
 		Args:  cobra.MaximumNArgs(1),
-		RunE:  WithNamespace(u.run),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) == 0 {
+				return version.NewUpdater().UpdateBinary()
+			}
+			return WithNamespace(u.run)(cmd, args)
+		},
 	}
 	return u
 }
@@ -28,26 +33,12 @@ func newUpdateCommand() *updateCommand {
 // Private
 
 func (u *updateCommand) run(ctx context.Context, ns *docker.Namespace, cmd *cobra.Command, args []string) error {
-	if len(args) == 0 {
-		return version.NewUpdater().UpdateBinary()
-	}
-
 	appName := args[0]
-	progress := func(p docker.DeployProgress) {
-		switch p.Stage {
-		case docker.DeployStageDownloading:
-			fmt.Printf("Downloading: %d%%\n", p.Percentage)
-		case docker.DeployStageStarting:
-			fmt.Println("Starting...")
-		case docker.DeployStageFinished:
-			fmt.Println("Finished")
-		}
-	}
 
 	var changed bool
 	err := withApplication(ns, appName, "updating", func(app *docker.Application) error {
 		var err error
-		changed, err = app.Update(ctx, progress)
+		changed, err = app.Update(ctx, printDeployProgress)
 		return err
 	})
 	if err != nil {


### PR DESCRIPTION
The update command has been extended to accept an optional argument: the name of a  deployed application.

Without an argument (`once update`), the behaviour is unchanged: the Once binary is updated  to the latest version.

With an argument (once update my-app), the command forces an update check for the application.

This is the same logic used by the background runner (app.Update), but triggered on demand rather than on a 24-hour interval. Progress is printed to the console (download, starting, finished), just like once deploy.

To me this is useful when actively developping, allowing me to make a custom crontab and force update every 5 min for example.

*full disclosure : this is coded with Claude code, I am not really proficient in go*