### PR TITLE
Remove proxy entry if HTTP verification fails

### DIFF
--- a/integration/docker_test.go
+++ b/integration/docker_test.go
@@ -634,6 +634,36 @@ func TestRemoveApplication(t *testing.T) {
 	assert.NoError(t, err, "volume should still exist")
 }
 
+func TestVerifyHTTPOrRemoveAllowsRedeployWithSameHost(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	ns, err := docker.NewNamespace("once-verify-redeploy-test")
+	require.NoError(t, err)
+	defer ns.Teardown(ctx, true)
+
+	require.NoError(t, ns.EnsureNetwork(ctx))
+	require.NoError(t, ns.Proxy().Boot(ctx, getProxyPorts(t)))
+
+	app := deployApp(t, ctx, ns, docker.ApplicationSettings{
+		Name:  "first",
+		Image: "ghcr.io/basecamp/once-campfire:main",
+		Host:  "reuse.invalid",
+	})
+
+	err = app.VerifyHTTPOrRemove(ctx)
+	require.ErrorIs(t, err, docker.ErrVerificationFailed)
+
+	require.NoError(t, ns.Refresh(ctx))
+	assert.False(t, ns.HostInUse("reuse.invalid"))
+
+	deployApp(t, ctx, ns, docker.ApplicationSettings{
+		Name:  "second",
+		Image: "ghcr.io/basecamp/once-campfire:main",
+		Host:  "reuse.invalid",
+	})
+}
+
 func TestRemoveApplicationWithData(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()

--- a/internal/command/deploy.go
+++ b/internal/command/deploy.go
@@ -77,10 +77,7 @@ func (d *deployCommand) run(ctx context.Context, ns *docker.Namespace, cmd *cobr
 	}
 
 	fmt.Println("Verifying...")
-	if err := app.VerifyHTTP(ctx); err != nil {
-		if cleanupErr := app.Destroy(context.Background(), true); cleanupErr != nil {
-			slog.Error("Failed to clean up after verification failure", "app", name, "error", cleanupErr)
-		}
+	if err := app.VerifyHTTPOrRemove(ctx); err != nil {
 		return err
 	}
 

--- a/internal/docker/application.go
+++ b/internal/docker/application.go
@@ -31,7 +31,7 @@ var (
 	ErrDeployFailed       = errors.New("deploy failed")
 	ErrVerificationFailed = &describedError{
 		msg:         "verification failed",
-		description: "The application did not respond to a health check after starting. It may have crashed or need longer to start up.",
+		description: "The application couldn't be verified. Please check that you have a valid DNS record set up.",
 	}
 	ErrUnpauseFailed = errors.New("failed to unpause container after backup")
 )

--- a/internal/docker/application.go
+++ b/internal/docker/application.go
@@ -24,16 +24,16 @@ var (
 	ErrInvalidBackup      = errors.New("invalid backup archive")
 	ErrBackupPathRelative = errors.New("backup path must be absolute")
 	ErrSetupFailed        = errors.New("setup failed")
-	ErrPullFailed = &describedError{
+	ErrPullFailed         = &describedError{
 		msg:         "pull failed",
 		description: "Failed to download the application image. Check that the image name is correct and try again.",
 	}
-	ErrDeployFailed = errors.New("deploy failed")
+	ErrDeployFailed       = errors.New("deploy failed")
 	ErrVerificationFailed = &describedError{
 		msg:         "verification failed",
 		description: "The application did not respond to a health check after starting. It may have crashed or need longer to start up.",
 	}
-	ErrUnpauseFailed      = errors.New("failed to unpause container after backup")
+	ErrUnpauseFailed = errors.New("failed to unpause container after backup")
 )
 
 const (
@@ -196,26 +196,12 @@ func (a *Application) Deploy(ctx context.Context, progress DeployProgressCallbac
 	return a.deployWithVolume(ctx, vol, progress)
 }
 
-func (a *Application) VerifyHTTP(ctx context.Context) error {
-	url := a.URL()
-	if url == "" {
-		return nil
-	}
-
-	client := &http.Client{Timeout: httpVerifyTimeout}
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url+HealthCheckPath, nil)
-	if err != nil {
-		return fmt.Errorf("%w: %w", ErrVerificationFailed, err)
-	}
-
-	resp, err := client.Do(req)
-	if err != nil {
-		return fmt.Errorf("%w: %w", ErrVerificationFailed, err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode < 200 || resp.StatusCode > 299 {
-		return fmt.Errorf("%w: unexpected status %d from %s", ErrVerificationFailed, resp.StatusCode, url)
+func (a *Application) VerifyHTTPOrRemove(ctx context.Context) error {
+	if err := a.verifyHTTP(ctx); err != nil {
+		if cleanupErr := a.Remove(context.Background(), true); cleanupErr != nil {
+			slog.Error("Failed to clean up after verification failure", "app", a.Settings.Name, "error", cleanupErr)
+		}
+		return err
 	}
 
 	return nil
@@ -382,26 +368,29 @@ func (a *Application) deployWithVolume(ctx context.Context, vol *ApplicationVolu
 	return nil
 }
 
-func (a *Application) volumeMounts(vol *ApplicationVolume) []mount.Mount {
-	var mounts []mount.Mount
-	for _, target := range AppVolumeMountTargets {
-		mounts = append(mounts, mount.Mount{
-			Type:   mount.TypeVolume,
-			Source: vol.Name(),
-			Target: target,
-		})
+func (a *Application) verifyHTTP(ctx context.Context) error {
+	url := a.URL()
+	if url == "" {
+		return nil
 	}
-	return mounts
-}
 
-func (a *Application) containerConfig(env []string) *container.Config {
-	return &container.Config{
-		Image: a.Settings.Image,
-		Labels: map[string]string{
-			labelKey: a.Settings.Marshal(),
-		},
-		Env: env,
+	client := &http.Client{Timeout: httpVerifyTimeout}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url+HealthCheckPath, nil)
+	if err != nil {
+		return fmt.Errorf("%w: %w", ErrVerificationFailed, err)
 	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("%w: %w", ErrVerificationFailed, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		return fmt.Errorf("%w: unexpected status %d from %s", ErrVerificationFailed, resp.StatusCode, url)
+	}
+
+	return nil
 }
 
 func (a *Application) removeContainersExcept(ctx context.Context, keep string) error {
@@ -423,4 +412,26 @@ func (a *Application) removeContainersExcept(ctx context.Context, keep string) e
 	}
 
 	return nil
+}
+
+func (a *Application) volumeMounts(vol *ApplicationVolume) []mount.Mount {
+	var mounts []mount.Mount
+	for _, target := range AppVolumeMountTargets {
+		mounts = append(mounts, mount.Mount{
+			Type:   mount.TypeVolume,
+			Source: vol.Name(),
+			Target: target,
+		})
+	}
+	return mounts
+}
+
+func (a *Application) containerConfig(env []string) *container.Config {
+	return &container.Config{
+		Image: a.Settings.Image,
+		Labels: map[string]string{
+			labelKey: a.Settings.Marshal(),
+		},
+		Env: env,
+	}
 }

--- a/internal/docker/application_test.go
+++ b/internal/docker/application_test.go
@@ -22,7 +22,7 @@ func TestVerifyHTTP_Success(t *testing.T) {
 		Settings: ApplicationSettings{Host: server.Listener.Addr().String(), DisableTLS: true},
 	}
 
-	err := app.VerifyHTTP(context.Background())
+	err := app.verifyHTTP(context.Background())
 	assert.NoError(t, err)
 	assert.Equal(t, HealthCheckPath, requestPath)
 }
@@ -41,7 +41,7 @@ func TestVerifyHTTP_RedirectToSuccess(t *testing.T) {
 		Settings: ApplicationSettings{Host: server.Listener.Addr().String(), DisableTLS: true},
 	}
 
-	err := app.VerifyHTTP(context.Background())
+	err := app.verifyHTTP(context.Background())
 	assert.NoError(t, err)
 }
 
@@ -55,7 +55,7 @@ func TestVerifyHTTP_ServerError(t *testing.T) {
 		Settings: ApplicationSettings{Host: server.Listener.Addr().String(), DisableTLS: true},
 	}
 
-	err := app.VerifyHTTP(context.Background())
+	err := app.verifyHTTP(context.Background())
 	require.Error(t, err)
 	assert.ErrorIs(t, err, ErrVerificationFailed)
 	assert.Contains(t, err.Error(), "unexpected status 500")
@@ -66,7 +66,7 @@ func TestVerifyHTTP_Unreachable(t *testing.T) {
 		Settings: ApplicationSettings{Host: "127.0.0.1:1", DisableTLS: true},
 	}
 
-	err := app.VerifyHTTP(context.Background())
+	err := app.verifyHTTP(context.Background())
 	require.Error(t, err)
 	assert.ErrorIs(t, err, ErrVerificationFailed)
 }
@@ -76,7 +76,7 @@ func TestVerifyHTTP_NoHost(t *testing.T) {
 		Settings: ApplicationSettings{},
 	}
 
-	err := app.VerifyHTTP(context.Background())
+	err := app.verifyHTTP(context.Background())
 	assert.NoError(t, err)
 }
 

--- a/internal/ui/install.go
+++ b/internal/ui/install.go
@@ -197,7 +197,7 @@ func (m Install) Update(msg tea.Msg) (Component, tea.Cmd) {
 		return m, nil
 
 	case InstallFormSubmitMsg:
-		if m.namespace != nil && m.namespace.HostInUse(msg.Hostname) {
+		if m.namespace.HostInUse(msg.Hostname) {
 			m.err = docker.ErrHostnameInUse
 			return m, nil
 		}
@@ -349,7 +349,7 @@ func (m Install) imageErrorState() installState {
 }
 
 func (m Install) showLogo() bool {
-	return m.namespace == nil || len(m.namespace.Applications()) == 0
+	return len(m.namespace.Applications()) == 0
 }
 
 func (m Install) middleHeight() int {

--- a/internal/ui/install.go
+++ b/internal/ui/install.go
@@ -1,6 +1,7 @@
 package ui
 
 import (
+	"context"
 	"errors"
 	"strings"
 
@@ -206,6 +207,7 @@ func (m Install) Update(msg tea.Msg) (Component, tea.Cmd) {
 		return m, m.activity.Init()
 
 	case InstallActivityFailedMsg:
+		_ = m.namespace.Refresh(context.Background())
 		m.activity = nil
 		m.err = msg.Err
 		if errors.Is(msg.Err, docker.ErrPullFailed) {
@@ -213,6 +215,7 @@ func (m Install) Update(msg tea.Msg) (Component, tea.Cmd) {
 		} else {
 			m.state = installStateHostname
 		}
+
 		return m, nil
 
 	case InstallActivityDoneMsg:

--- a/internal/ui/install_activity.go
+++ b/internal/ui/install_activity.go
@@ -201,10 +201,7 @@ func (m *InstallActivity) runInstall(ctx context.Context) {
 
 	m.progressChan <- installProgressMsg{stage: stageVerifying}
 
-	if err := app.VerifyHTTP(ctx); err != nil {
-		if cleanupErr := app.Destroy(context.Background(), true); cleanupErr != nil {
-			slog.Error("Failed to clean up after verification failure", "app", appName, "error", cleanupErr)
-		}
+	if err := app.VerifyHTTPOrRemove(ctx); err != nil {
 		m.doneChan <- installDoneMsg{err: err}
 		return
 	}

--- a/internal/ui/install_test.go
+++ b/internal/ui/install_test.go
@@ -45,12 +45,12 @@ func TestInstall_CustomImageFlow(t *testing.T) {
 }
 
 func TestInstall_CLIModeSkipsToHostname(t *testing.T) {
-	m := NewInstall(nil, "campfire")
+	m := NewInstall(newTestNamespace(), "campfire")
 	assert.Equal(t, installStateHostname, m.state)
 }
 
 func TestInstall_CLIModeExpandsAlias(t *testing.T) {
-	m := NewInstall(nil, "campfire")
+	m := NewInstall(newTestNamespace(), "campfire")
 	m, _ = updateInstall(m, tea.WindowSizeMsg{Width: 80, Height: 40})
 	view := ansi.Strip(m.View())
 	assert.Contains(t, view, "once-campfire.example.com")
@@ -180,7 +180,7 @@ func TestInstall_BackNavigation_ImageFormBackMsg(t *testing.T) {
 }
 
 func TestInstall_EscQuitsInCLIMode(t *testing.T) {
-	m := NewInstall(nil, "ghcr.io/basecamp/once-campfire:latest")
+	m := NewInstall(newTestNamespace(), "ghcr.io/basecamp/once-campfire:latest")
 
 	_, cmd := updateInstall(m, keyPressMsg("esc"))
 	require.NotNil(t, cmd)
@@ -191,7 +191,7 @@ func TestInstall_EscQuitsInCLIMode(t *testing.T) {
 }
 
 func TestInstall_HostnameBackQuitsInCLIMode(t *testing.T) {
-	m := NewInstall(nil, "ghcr.io/basecamp/once-campfire:latest")
+	m := NewInstall(newTestNamespace(), "ghcr.io/basecamp/once-campfire:latest")
 
 	_, cmd := updateInstall(m, InstallHostnameBackMsg{})
 	require.NotNil(t, cmd)
@@ -202,7 +202,7 @@ func TestInstall_HostnameBackQuitsInCLIMode(t *testing.T) {
 }
 
 func TestInstall_ShowsLogoAndHidesTitleWhenNoApps(t *testing.T) {
-	m := NewInstall(nil, "")
+	m := NewInstall(newTestNamespace(), "")
 	m, _ = updateInstall(m, tea.WindowSizeMsg{Width: 80, Height: 40})
 
 	view := m.View()
@@ -371,7 +371,7 @@ func TestBlockWidthEmpty(t *testing.T) {
 // Helpers
 
 func newTestInstall() Install {
-	return NewInstall(nil, "")
+	return NewInstall(newTestNamespace(), "")
 }
 
 func newTestNamespace(apps ...docker.ApplicationSettings) *docker.Namespace {

--- a/internal/ui/install_test.go
+++ b/internal/ui/install_test.go
@@ -86,7 +86,8 @@ func TestInstall_SuccessNavigatesToApp(t *testing.T) {
 }
 
 func TestInstall_FailureReturnsToHostname(t *testing.T) {
-	m := newTestInstall()
+	ns := newTestNamespace()
+	m := NewInstall(ns, "")
 	m, _ = updateInstall(m, tea.WindowSizeMsg{Width: 80, Height: 24})
 
 	// Go through known app flow to hostname
@@ -220,7 +221,8 @@ func TestInstall_ShowsTitleAndHidesLogoWhenAppsExist(t *testing.T) {
 }
 
 func TestInstall_PullFailureReturnsToImageForm(t *testing.T) {
-	m := newTestInstall()
+	ns := newTestNamespace()
+	m := NewInstall(ns, "")
 	m, _ = updateInstall(m, tea.WindowSizeMsg{Width: 80, Height: 24})
 	m, _ = updateInstall(m, InstallCustomSelectedMsg{})
 	m, _ = updateInstall(m, InstallImageSubmitMsg{ImageRef: "bad:image"})
@@ -234,7 +236,8 @@ func TestInstall_PullFailureReturnsToImageForm(t *testing.T) {
 }
 
 func TestInstall_PullFailureReturnsToAppList(t *testing.T) {
-	m := newTestInstall()
+	ns := newTestNamespace()
+	m := NewInstall(ns, "")
 	m, _ = updateInstall(m, tea.WindowSizeMsg{Width: 80, Height: 24})
 	m, _ = updateInstall(m, InstallAppSelectedMsg{ImageRef: "ghcr.io/basecamp/once-campfire"})
 	m, _ = updateInstall(m, InstallFormSubmitMsg{ImageRef: "ghcr.io/basecamp/once-campfire", Hostname: "chat.example.com"})
@@ -247,7 +250,8 @@ func TestInstall_PullFailureReturnsToAppList(t *testing.T) {
 }
 
 func TestInstall_NonPullDeployFailureReturnsToHostname(t *testing.T) {
-	m := newTestInstall()
+	ns := newTestNamespace()
+	m := NewInstall(ns, "")
 	m, _ = updateInstall(m, tea.WindowSizeMsg{Width: 80, Height: 24})
 	m, _ = updateInstall(m, InstallAppSelectedMsg{ImageRef: "ghcr.io/basecamp/once-campfire"})
 	m, _ = updateInstall(m, InstallFormSubmitMsg{ImageRef: "ghcr.io/basecamp/once-campfire", Hostname: "chat.example.com"})
@@ -281,7 +285,8 @@ func TestInstall_UniqueHostnameAllowsInstall(t *testing.T) {
 }
 
 func TestInstall_FailureDoesNotRestartLogo(t *testing.T) {
-	noApps := NewInstall(nil, "")
+	ns := newTestNamespace()
+	noApps := NewInstall(ns, "")
 	noApps, _ = updateInstall(noApps, tea.WindowSizeMsg{Width: 80, Height: 40})
 	noApps, _ = updateInstall(noApps, InstallFormSubmitMsg{ImageRef: "ghcr.io/basecamp/once-campfire:latest", Hostname: "app.example.com"})
 	_, cmd := updateInstall(noApps, InstallActivityFailedMsg{Err: errors.New("fail")})


### PR DESCRIPTION
If a new deployment fails at the verifying stage, we need to ensure that:
- Its proxy entry is removed (as it's now stale)
- The namespace's list of applications is refreshed

Fixes #23 