### PR TITLE
Cli deploy flags

### DIFF
--- a/integration/docker_test.go
+++ b/integration/docker_test.go
@@ -692,6 +692,128 @@ func TestRemoveApplicationWithData(t *testing.T) {
 	assert.ErrorIs(t, err, docker.ErrVolumeNotFound)
 }
 
+func TestDeployWithSettings(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	ns, err := docker.NewNamespace("once-settings-test")
+	require.NoError(t, err)
+	defer ns.Teardown(ctx, true)
+
+	require.NoError(t, ns.EnsureNetwork(ctx))
+	require.NoError(t, ns.Proxy().Boot(ctx, getProxyPorts(t)))
+
+	settings := docker.ApplicationSettings{
+		Name:       "settingsapp",
+		Image:      "ghcr.io/basecamp/once-campfire:main",
+		Host:       "settingsapp.localhost",
+		DisableTLS: true,
+		EnvVars:    map[string]string{"CUSTOM_VAR": "custom_value", "ANOTHER": "thing"},
+		SMTP: docker.SMTPSettings{
+			Server:   "smtp.example.com",
+			Port:     "587",
+			Username: "user",
+			Password: "pass",
+			From:     "noreply@example.com",
+		},
+		Resources:  docker.ContainerResources{CPUs: 1, MemoryMB: 512},
+		AutoUpdate: false,
+		Backup:     docker.BackupSettings{Path: "/backups", AutoBackup: true},
+	}
+
+	app := deployApp(t, ctx, ns, settings)
+
+	// Verify settings persisted via label restore
+	ns2, err := docker.RestoreNamespace(ctx, "once-settings-test")
+	require.NoError(t, err)
+
+	restored := ns2.Application("settingsapp")
+	require.NotNil(t, restored)
+	assert.True(t, restored.Settings.DisableTLS)
+	assert.Equal(t, "custom_value", restored.Settings.EnvVars["CUSTOM_VAR"])
+	assert.Equal(t, "thing", restored.Settings.EnvVars["ANOTHER"])
+	assert.Equal(t, "smtp.example.com", restored.Settings.SMTP.Server)
+	assert.Equal(t, "587", restored.Settings.SMTP.Port)
+	assert.False(t, restored.Settings.AutoUpdate)
+	assert.Equal(t, "/backups", restored.Settings.Backup.Path)
+	assert.True(t, restored.Settings.Backup.AutoBackup)
+
+	// Verify container env vars
+	containerName, err := app.ContainerName(ctx)
+	require.NoError(t, err)
+	envVars := inspectContainerEnv(t, ctx, containerName)
+	assert.Contains(t, envVars, "CUSTOM_VAR=custom_value")
+	assert.Contains(t, envVars, "ANOTHER=thing")
+	assert.Contains(t, envVars, "SMTP_ADDRESS=smtp.example.com")
+
+	// Verify container resources
+	assertContainerResources(t, ctx, containerName, 1e9, 512*1024*1024)
+}
+
+func TestRedeployToExistingHost(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	ns, err := docker.NewNamespace("once-redeploy-test")
+	require.NoError(t, err)
+	defer ns.Teardown(ctx, true)
+
+	require.NoError(t, ns.EnsureNetwork(ctx))
+	require.NoError(t, ns.Proxy().Boot(ctx, getProxyPorts(t)))
+
+	// Initial deploy with settings
+	initialSettings := docker.ApplicationSettings{
+		Name:    "redeployapp",
+		Image:   "ghcr.io/basecamp/once-campfire:main",
+		Host:    "redeploy.localhost",
+		EnvVars: map[string]string{"OLD_VAR": "old_value"},
+		SMTP: docker.SMTPSettings{
+			Server: "smtp.old.com",
+			Port:   "25",
+		},
+		Resources: docker.ContainerResources{CPUs: 2, MemoryMB: 1024},
+	}
+
+	app := deployApp(t, ctx, ns, initialSettings)
+	vol, err := app.Volume(ctx)
+	require.NoError(t, err)
+	originalSecretKeyBase := vol.SecretKeyBase()
+
+	// Redeploy to the same host with different settings via DeployApplication
+	newSettings := docker.ApplicationSettings{
+		Image:   "ghcr.io/basecamp/once-campfire:main",
+		Host:    "redeploy.localhost",
+		EnvVars: map[string]string{"NEW_VAR": "new_value"},
+	}
+
+	redeployedApp, isNew, err := ns.DeployApplication(ctx, newSettings, nil)
+	require.NoError(t, err)
+	assert.False(t, isNew)
+	require.NoError(t, ns.Refresh(ctx))
+
+	// Should still be one app
+	assert.Len(t, ns.Applications(), 1)
+
+	// Name preserved
+	assert.Equal(t, "redeployapp", redeployedApp.Settings.Name)
+
+	// Volume preserved
+	vol2, err := redeployedApp.Volume(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, originalSecretKeyBase, vol2.SecretKeyBase())
+
+	// New env vars present, old ones gone
+	containerName, err := redeployedApp.ContainerName(ctx)
+	require.NoError(t, err)
+	envVars := inspectContainerEnv(t, ctx, containerName)
+	assert.Contains(t, envVars, "NEW_VAR=new_value")
+	assertEnvAbsent(t, envVars, "OLD_VAR")
+	assertEnvAbsent(t, envVars, "SMTP_ADDRESS")
+
+	// Resources cleared (zero values)
+	assertContainerResources(t, ctx, containerName, 0, 0)
+}
+
 // Helpers
 
 func TestContainerResources(t *testing.T) {
@@ -1033,6 +1155,27 @@ func buildTestBackup(t *testing.T, imageName string) []byte {
 	require.NoError(t, gw.Close())
 
 	return buf.Bytes()
+}
+
+func inspectContainerEnv(t *testing.T, ctx context.Context, name string) []string {
+	t.Helper()
+	c, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
+	require.NoError(t, err)
+	defer c.Close()
+
+	info, err := c.ContainerInspect(ctx, name)
+	require.NoError(t, err)
+	return info.Config.Env
+}
+
+func assertEnvAbsent(t *testing.T, envVars []string, key string) {
+	t.Helper()
+	prefix := key + "="
+	for _, e := range envVars {
+		if strings.HasPrefix(e, prefix) {
+			t.Errorf("expected env var %s to be absent, but found %s", key, e)
+		}
+	}
 }
 
 func extractTarGz(t *testing.T, r io.Reader) map[string][]byte {

--- a/integration/docker_test.go
+++ b/integration/docker_test.go
@@ -750,68 +750,117 @@ func TestDeployWithSettings(t *testing.T) {
 	assertContainerResources(t, ctx, containerName, 1e9, 512*1024*1024)
 }
 
-func TestRedeployToExistingHost(t *testing.T) {
+func TestUpdatePreservesSettings(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()
 
-	ns, err := docker.NewNamespace("once-redeploy-test")
+	ns, err := docker.NewNamespace("once-update-test")
 	require.NoError(t, err)
 	defer ns.Teardown(ctx, true)
 
 	require.NoError(t, ns.EnsureNetwork(ctx))
 	require.NoError(t, ns.Proxy().Boot(ctx, getProxyPorts(t)))
 
-	// Initial deploy with settings
-	initialSettings := docker.ApplicationSettings{
-		Name:    "redeployapp",
+	// Deploy with full settings
+	app := deployApp(t, ctx, ns, docker.ApplicationSettings{
+		Name:    "updateapp",
 		Image:   "ghcr.io/basecamp/once-campfire:main",
-		Host:    "redeploy.localhost",
-		EnvVars: map[string]string{"OLD_VAR": "old_value"},
+		Host:    "update.localhost",
+		EnvVars: map[string]string{"MY_VAR": "my_value"},
 		SMTP: docker.SMTPSettings{
-			Server: "smtp.old.com",
-			Port:   "25",
+			Server: "smtp.example.com",
+			Port:   "587",
 		},
 		Resources: docker.ContainerResources{CPUs: 2, MemoryMB: 1024},
-	}
+	})
 
-	app := deployApp(t, ctx, ns, initialSettings)
 	vol, err := app.Volume(ctx)
 	require.NoError(t, err)
 	originalSecretKeyBase := vol.SecretKeyBase()
 
-	// Redeploy to the same host with different settings via DeployApplication
-	newSettings := docker.ApplicationSettings{
-		Image:   "ghcr.io/basecamp/once-campfire:main",
-		Host:    "redeploy.localhost",
-		EnvVars: map[string]string{"NEW_VAR": "new_value"},
-	}
-
-	redeployedApp, isNew, err := ns.DeployApplication(ctx, newSettings, nil)
-	require.NoError(t, err)
-	assert.False(t, isNew)
+	// Update only the env vars, leaving everything else as-is
+	newSettings := app.Settings
+	newSettings.EnvVars = map[string]string{"NEW_VAR": "new_value"}
+	app.Settings = newSettings
+	require.NoError(t, app.Deploy(ctx, nil))
 	require.NoError(t, ns.Refresh(ctx))
 
-	// Should still be one app
-	assert.Len(t, ns.Applications(), 1)
+	updatedApp := ns.ApplicationByHost("update.localhost")
+	require.NotNil(t, updatedApp)
 
 	// Name preserved
-	assert.Equal(t, "redeployapp", redeployedApp.Settings.Name)
+	assert.Equal(t, "updateapp", updatedApp.Settings.Name)
 
-	// Volume preserved
-	vol2, err := redeployedApp.Volume(ctx)
-	require.NoError(t, err)
-	assert.Equal(t, originalSecretKeyBase, vol2.SecretKeyBase())
+	// SMTP and resources preserved
+	assert.Equal(t, "smtp.example.com", updatedApp.Settings.SMTP.Server)
+	assert.Equal(t, "587", updatedApp.Settings.SMTP.Port)
+	assert.Equal(t, 2, updatedApp.Settings.Resources.CPUs)
+	assert.Equal(t, 1024, updatedApp.Settings.Resources.MemoryMB)
 
-	// New env vars present, old ones gone
-	containerName, err := redeployedApp.ContainerName(ctx)
+	// Env vars replaced
+	containerName, err := updatedApp.ContainerName(ctx)
 	require.NoError(t, err)
 	envVars := inspectContainerEnv(t, ctx, containerName)
 	assert.Contains(t, envVars, "NEW_VAR=new_value")
-	assertEnvAbsent(t, envVars, "OLD_VAR")
-	assertEnvAbsent(t, envVars, "SMTP_ADDRESS")
+	assertEnvAbsent(t, envVars, "MY_VAR")
 
-	// Resources cleared (zero values)
-	assertContainerResources(t, ctx, containerName, 0, 0)
+	// Volume preserved
+	vol2, err := updatedApp.Volume(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, originalSecretKeyBase, vol2.SecretKeyBase())
+}
+
+func TestUpdateChangeHost(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	ns, err := docker.NewNamespace("once-update-host-test")
+	require.NoError(t, err)
+	defer ns.Teardown(ctx, true)
+
+	require.NoError(t, ns.EnsureNetwork(ctx))
+	require.NoError(t, ns.Proxy().Boot(ctx, getProxyPorts(t)))
+
+	app := deployApp(t, ctx, ns, docker.ApplicationSettings{
+		Name:  "hostchangeapp",
+		Image: "ghcr.io/basecamp/once-campfire:main",
+		Host:  "old.localhost",
+	})
+
+	// Change the host
+	app.Settings.Host = "new.localhost"
+	require.NoError(t, app.Deploy(ctx, nil))
+	require.NoError(t, ns.Refresh(ctx))
+
+	assert.Nil(t, ns.ApplicationByHost("old.localhost"))
+	assert.NotNil(t, ns.ApplicationByHost("new.localhost"))
+}
+
+func TestUpdateHostCollision(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	ns, err := docker.NewNamespace("once-update-collision-test")
+	require.NoError(t, err)
+	defer ns.Teardown(ctx, true)
+
+	require.NoError(t, ns.EnsureNetwork(ctx))
+	require.NoError(t, ns.Proxy().Boot(ctx, getProxyPorts(t)))
+
+	deployApp(t, ctx, ns, docker.ApplicationSettings{
+		Name:  "app1",
+		Image: "ghcr.io/basecamp/once-campfire:main",
+		Host:  "host1.localhost",
+	})
+
+	app2 := deployApp(t, ctx, ns, docker.ApplicationSettings{
+		Name:  "app2",
+		Image: "ghcr.io/basecamp/once-campfire:main",
+		Host:  "host2.localhost",
+	})
+
+	// Attempting to change app2's host to app1's host should be detected
+	assert.True(t, ns.HostInUseByAnother("host1.localhost", app2.Settings.Name))
 }
 
 // Helpers

--- a/internal/command/backup.go
+++ b/internal/command/backup.go
@@ -17,7 +17,7 @@ type backupCommand struct {
 func newBackupCommand() *backupCommand {
 	b := &backupCommand{}
 	b.cmd = &cobra.Command{
-		Use:   "backup <app> <filename>",
+		Use:   "backup <host> <filename>",
 		Short: "Backup an application to a file",
 		Args:  cobra.ExactArgs(2),
 		RunE:  WithNamespace(b.run),
@@ -28,19 +28,19 @@ func newBackupCommand() *backupCommand {
 // Private
 
 func (b *backupCommand) run(ctx context.Context, ns *docker.Namespace, cmd *cobra.Command, args []string) error {
-	appName := args[0]
+	host := args[0]
 	filename := args[1]
 
 	dir := filepath.Dir(filename)
 	name := filepath.Base(filename)
 
-	err := withApplication(ns, appName, "backing up", func(app *docker.Application) error {
+	err := withApplication(ns, host, "backing up", func(app *docker.Application) error {
 		return app.BackupToFile(ctx, dir, name)
 	})
 	if err != nil {
 		return err
 	}
 
-	fmt.Printf("Backed up %s to %s\n", appName, filename)
+	fmt.Printf("Backed up %s to %s\n", host, filename)
 	return nil
 }

--- a/internal/command/backup.go
+++ b/internal/command/backup.go
@@ -29,12 +29,15 @@ func newBackupCommand() *backupCommand {
 
 func (b *backupCommand) run(ctx context.Context, ns *docker.Namespace, cmd *cobra.Command, args []string) error {
 	host := args[0]
-	filename := args[1]
+	filename, err := filepath.Abs(args[1])
+	if err != nil {
+		return fmt.Errorf("resolving path: %w", err)
+	}
 
 	dir := filepath.Dir(filename)
 	name := filepath.Base(filename)
 
-	err := withApplication(ns, host, "backing up", func(app *docker.Application) error {
+	err = withApplication(ns, host, "backing up", func(app *docker.Application) error {
 		return app.BackupToFile(ctx, dir, name)
 	})
 	if err != nil {

--- a/internal/command/cli_progress.go
+++ b/internal/command/cli_progress.go
@@ -1,0 +1,122 @@
+package command
+
+import (
+	"fmt"
+
+	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
+
+	"github.com/basecamp/once/internal/docker"
+	"github.com/basecamp/once/internal/ui"
+)
+
+type cliProgress struct {
+	label        string
+	stage        string
+	progress     ui.Progress
+	progressChan chan docker.DeployProgress
+	err          error
+	width        int
+
+	task func(docker.DeployProgressCallback) error
+}
+
+type cliProgressDoneMsg struct{ err error }
+type cliProgressUpdateMsg struct{ p docker.DeployProgress }
+
+func newCLIProgress(label string, task func(docker.DeployProgressCallback) error) *cliProgress {
+	return &cliProgress{
+		label:        label,
+		stage:        "preparing",
+		progress:     ui.NewProgress(0, lipgloss.BrightBlue),
+		progressChan: make(chan docker.DeployProgress, 16),
+		task:         task,
+	}
+}
+
+func (m *cliProgress) Run() error {
+	_, err := tea.NewProgram(m).Run()
+	if err != nil {
+		return err
+	}
+
+	if m.err != nil {
+		fmt.Printf("%s: %s\n", m.label, lipgloss.NewStyle().Foreground(lipgloss.Red).Render("failed"))
+	} else {
+		fmt.Printf("%s: %s\n", m.label, lipgloss.NewStyle().Foreground(lipgloss.Green).Render("done"))
+	}
+
+	return m.err
+}
+
+func (m *cliProgress) Init() tea.Cmd {
+	return tea.Batch(
+		m.runTask(),
+		m.waitForProgress(),
+		m.progress.Init(),
+	)
+}
+
+func (m *cliProgress) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		m.width = msg.Width
+		m.progress = m.progress.SetWidth(m.barWidth())
+		return m, nil
+
+	case cliProgressUpdateMsg:
+		switch msg.p.Stage {
+		case docker.DeployStageDownloading:
+			m.stage = "downloading"
+			m.progress = m.progress.SetPercent(msg.p.Percentage)
+		case docker.DeployStageStarting:
+			m.stage = "starting"
+			m.progress = m.progress.SetPercent(-1)
+		}
+		return m, m.waitForProgress()
+
+	case cliProgressDoneMsg:
+		m.err = msg.err
+		return m, tea.Quit
+
+	case ui.ProgressTickMsg:
+		var cmd tea.Cmd
+		m.progress, cmd = m.progress.Update(msg)
+		return m, cmd
+	}
+
+	return m, nil
+}
+
+func (m *cliProgress) View() tea.View {
+	prefix := m.label + " " + m.stage + ": "
+	return tea.NewView(prefix + m.progress.View())
+}
+
+// Private
+
+func (m *cliProgress) barWidth() int {
+	prefixWidth := len(m.label) + 1 + len(m.stage) + 2 // " " + stage + ": "
+	w := m.width - prefixWidth
+	if w < 10 {
+		w = 10
+	}
+	return w
+}
+
+func (m *cliProgress) runTask() tea.Cmd {
+	return func() tea.Msg {
+		callback := func(p docker.DeployProgress) {
+			m.progressChan <- p
+		}
+		err := m.task(callback)
+		return cliProgressDoneMsg{err: err}
+	}
+}
+
+func (m *cliProgress) waitForProgress() tea.Cmd {
+	return func() tea.Msg {
+		p := <-m.progressChan
+		return cliProgressUpdateMsg{p: p}
+	}
+}

--- a/internal/command/deploy.go
+++ b/internal/command/deploy.go
@@ -48,6 +48,7 @@ func (d *deployCommand) run(ctx context.Context, ns *docker.Namespace, cmd *cobr
 	}
 
 	settings, err := d.flags.buildSettings(imageRef, host)
+
 	if err != nil {
 		return err
 	}

--- a/internal/command/deploy.go
+++ b/internal/command/deploy.go
@@ -3,7 +3,7 @@ package command
 import (
 	"context"
 	"fmt"
-	"log/slog"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -11,8 +11,20 @@ import (
 )
 
 type deployCommand struct {
-	cmd  *cobra.Command
-	host string
+	cmd          *cobra.Command
+	host         string
+	disableTLS   bool
+	env          []string
+	smtpServer   string
+	smtpPort     string
+	smtpUsername string
+	smtpPassword string
+	smtpFrom     string
+	cpus         int
+	memory       int
+	autoUpdate   bool
+	backupPath   string
+	autoBackup   bool
 }
 
 func newDeployCommand() *deployCommand {
@@ -23,7 +35,21 @@ func newDeployCommand() *deployCommand {
 		Args:  cobra.ExactArgs(1),
 		RunE:  WithNamespace(d.run),
 	}
+
 	d.cmd.Flags().StringVar(&d.host, "host", "", "hostname for the application (defaults to <name>.localhost)")
+	d.cmd.Flags().BoolVar(&d.disableTLS, "disable-tls", false, "disable TLS for this application")
+	d.cmd.Flags().StringArrayVar(&d.env, "env", nil, "environment variable in KEY=VALUE format (can be repeated)")
+	d.cmd.Flags().StringVar(&d.smtpServer, "smtp-server", "", "SMTP server address")
+	d.cmd.Flags().StringVar(&d.smtpPort, "smtp-port", "", "SMTP server port")
+	d.cmd.Flags().StringVar(&d.smtpUsername, "smtp-username", "", "SMTP username")
+	d.cmd.Flags().StringVar(&d.smtpPassword, "smtp-password", "", "SMTP password")
+	d.cmd.Flags().StringVar(&d.smtpFrom, "smtp-from", "", "SMTP from address")
+	d.cmd.Flags().IntVar(&d.cpus, "cpus", 0, "CPU limit for the container")
+	d.cmd.Flags().IntVar(&d.memory, "memory", 0, "memory limit in MB for the container")
+	d.cmd.Flags().BoolVar(&d.autoUpdate, "auto-update", true, "automatically update the application")
+	d.cmd.Flags().StringVar(&d.backupPath, "backup-path", "", "path for backups")
+	d.cmd.Flags().BoolVar(&d.autoBackup, "auto-backup", false, "enable automatic backups")
+
 	return d
 }
 
@@ -36,27 +62,38 @@ func (d *deployCommand) run(ctx context.Context, ns *docker.Namespace, cmd *cobr
 		return fmt.Errorf("%w: %w", docker.ErrSetupFailed, err)
 	}
 
-	baseName := docker.NameFromImageRef(imageRef)
-	name, err := ns.UniqueName(baseName)
-	if err != nil {
-		return fmt.Errorf("generating app name: %w", err)
-	}
-
 	host := d.host
 	if host == "" {
-		host = baseName + ".localhost"
+		host = docker.NameFromImageRef(imageRef) + ".localhost"
 	}
 
-	if ns.HostInUse(host) {
-		return docker.ErrHostnameInUse
+	envVars, err := d.parseEnvVars()
+	if err != nil {
+		return err
 	}
 
-	app := docker.NewApplication(ns, docker.ApplicationSettings{
-		Name:       name,
+	settings := docker.ApplicationSettings{
 		Image:      imageRef,
 		Host:       host,
-		AutoUpdate: true,
-	})
+		DisableTLS: d.disableTLS,
+		EnvVars:    envVars,
+		SMTP: docker.SMTPSettings{
+			Server:   d.smtpServer,
+			Port:     d.smtpPort,
+			Username: d.smtpUsername,
+			Password: d.smtpPassword,
+			From:     d.smtpFrom,
+		},
+		Resources: docker.ContainerResources{
+			CPUs:     d.cpus,
+			MemoryMB: d.memory,
+		},
+		AutoUpdate: d.autoUpdate,
+		Backup: docker.BackupSettings{
+			Path:       d.backupPath,
+			AutoBackup: d.autoBackup,
+		},
+	}
 
 	progress := func(p docker.DeployProgress) {
 		switch p.Stage {
@@ -69,18 +106,38 @@ func (d *deployCommand) run(ctx context.Context, ns *docker.Namespace, cmd *cobr
 		}
 	}
 
-	if err := app.Deploy(ctx, progress); err != nil {
-		if cleanupErr := app.Destroy(context.Background(), true); cleanupErr != nil {
-			slog.Error("Failed to clean up after deploy failure", "app", name, "error", cleanupErr)
-		}
+	app, isNew, err := ns.DeployApplication(ctx, settings, progress)
+	if err != nil {
 		return fmt.Errorf("%w: %w", docker.ErrDeployFailed, err)
 	}
 
-	fmt.Println("Verifying...")
-	if err := app.VerifyHTTPOrRemove(ctx); err != nil {
-		return err
+	if isNew {
+		fmt.Println("Verifying...")
+		if err := app.VerifyHTTPOrRemove(ctx); err != nil {
+			return err
+		}
 	}
 
-	fmt.Printf("Deployed %s\n", name)
+	fmt.Printf("Deployed %s\n", app.Settings.Name)
 	return nil
+}
+
+func (d *deployCommand) parseEnvVars() (map[string]string, error) {
+	if d.env == nil {
+		return nil, nil
+	}
+
+	envVars := make(map[string]string, len(d.env))
+	for _, e := range d.env {
+		key, value, ok := strings.Cut(e, "=")
+		if !ok {
+			return nil, fmt.Errorf("invalid environment variable %q: must be in KEY=VALUE format", e)
+		}
+		if key == "" {
+			return nil, fmt.Errorf("invalid environment variable %q: key must not be empty", e)
+		}
+		envVars[key] = value
+	}
+
+	return envVars, nil
 }

--- a/internal/command/deploy.go
+++ b/internal/command/deploy.go
@@ -61,29 +61,20 @@ func (d *deployCommand) run(ctx context.Context, ns *docker.Namespace, cmd *cobr
 
 	app := docker.NewApplication(ns, settings)
 
-	progress := func(p docker.DeployProgress) {
-		switch p.Stage {
-		case docker.DeployStageDownloading:
-			fmt.Printf("Downloading: %d%%\n", p.Percentage)
-		case docker.DeployStageStarting:
-			fmt.Println("Starting...")
-		case docker.DeployStageFinished:
-			fmt.Println("Finished")
+	p := newCLIProgress("Deploying "+host, func(progress docker.DeployProgressCallback) error {
+		if err := app.Deploy(ctx, progress); err != nil {
+			if cleanupErr := app.Destroy(context.Background(), true); cleanupErr != nil {
+				slog.Error("Failed to clean up after deploy failure", "app", name, "error", cleanupErr)
+			}
+			return fmt.Errorf("%w: %w", docker.ErrDeployFailed, err)
 		}
-	}
 
-	if err := app.Deploy(ctx, progress); err != nil {
-		if cleanupErr := app.Destroy(context.Background(), true); cleanupErr != nil {
-			slog.Error("Failed to clean up after deploy failure", "app", name, "error", cleanupErr)
+		if err := app.VerifyHTTPOrRemove(ctx); err != nil {
+			return err
 		}
-		return fmt.Errorf("%w: %w", docker.ErrDeployFailed, err)
-	}
 
-	fmt.Println("Verifying...")
-	if err := app.VerifyHTTPOrRemove(ctx); err != nil {
-		return err
-	}
+		return nil
+	})
 
-	fmt.Printf("Deployed %s\n", name)
-	return nil
+	return p.Run()
 }

--- a/internal/command/deploy.go
+++ b/internal/command/deploy.go
@@ -3,7 +3,7 @@ package command
 import (
 	"context"
 	"fmt"
-	"strings"
+	"log/slog"
 
 	"github.com/spf13/cobra"
 
@@ -11,20 +11,8 @@ import (
 )
 
 type deployCommand struct {
-	cmd          *cobra.Command
-	host         string
-	disableTLS   bool
-	env          []string
-	smtpServer   string
-	smtpPort     string
-	smtpUsername string
-	smtpPassword string
-	smtpFrom     string
-	cpus         int
-	memory       int
-	autoUpdate   bool
-	backupPath   string
-	autoBackup   bool
+	cmd   *cobra.Command
+	flags settingsFlags
 }
 
 func newDeployCommand() *deployCommand {
@@ -36,19 +24,7 @@ func newDeployCommand() *deployCommand {
 		RunE:  WithNamespace(d.run),
 	}
 
-	d.cmd.Flags().StringVar(&d.host, "host", "", "hostname for the application (defaults to <name>.localhost)")
-	d.cmd.Flags().BoolVar(&d.disableTLS, "disable-tls", false, "disable TLS for this application")
-	d.cmd.Flags().StringArrayVar(&d.env, "env", nil, "environment variable in KEY=VALUE format (can be repeated)")
-	d.cmd.Flags().StringVar(&d.smtpServer, "smtp-server", "", "SMTP server address")
-	d.cmd.Flags().StringVar(&d.smtpPort, "smtp-port", "", "SMTP server port")
-	d.cmd.Flags().StringVar(&d.smtpUsername, "smtp-username", "", "SMTP username")
-	d.cmd.Flags().StringVar(&d.smtpPassword, "smtp-password", "", "SMTP password")
-	d.cmd.Flags().StringVar(&d.smtpFrom, "smtp-from", "", "SMTP from address")
-	d.cmd.Flags().IntVar(&d.cpus, "cpus", 0, "CPU limit for the container")
-	d.cmd.Flags().IntVar(&d.memory, "memory", 0, "memory limit in MB for the container")
-	d.cmd.Flags().BoolVar(&d.autoUpdate, "auto-update", true, "automatically update the application")
-	d.cmd.Flags().StringVar(&d.backupPath, "backup-path", "", "path for backups")
-	d.cmd.Flags().BoolVar(&d.autoBackup, "auto-backup", false, "enable automatic backups")
+	d.flags.register(d.cmd)
 
 	return d
 }
@@ -62,38 +38,28 @@ func (d *deployCommand) run(ctx context.Context, ns *docker.Namespace, cmd *cobr
 		return fmt.Errorf("%w: %w", docker.ErrSetupFailed, err)
 	}
 
-	host := d.host
+	host := d.flags.host
 	if host == "" {
 		host = docker.NameFromImageRef(imageRef) + ".localhost"
 	}
 
-	envVars, err := d.parseEnvVars()
+	if ns.HostInUse(host) {
+		return docker.ErrHostnameInUse
+	}
+
+	settings, err := d.flags.buildSettings(imageRef, host)
 	if err != nil {
 		return err
 	}
 
-	settings := docker.ApplicationSettings{
-		Image:      imageRef,
-		Host:       host,
-		DisableTLS: d.disableTLS,
-		EnvVars:    envVars,
-		SMTP: docker.SMTPSettings{
-			Server:   d.smtpServer,
-			Port:     d.smtpPort,
-			Username: d.smtpUsername,
-			Password: d.smtpPassword,
-			From:     d.smtpFrom,
-		},
-		Resources: docker.ContainerResources{
-			CPUs:     d.cpus,
-			MemoryMB: d.memory,
-		},
-		AutoUpdate: d.autoUpdate,
-		Backup: docker.BackupSettings{
-			Path:       d.backupPath,
-			AutoBackup: d.autoBackup,
-		},
+	baseName := docker.NameFromImageRef(imageRef)
+	name, err := ns.UniqueName(baseName)
+	if err != nil {
+		return fmt.Errorf("generating app name: %w", err)
 	}
+	settings.Name = name
+
+	app := docker.NewApplication(ns, settings)
 
 	progress := func(p docker.DeployProgress) {
 		switch p.Stage {
@@ -106,38 +72,18 @@ func (d *deployCommand) run(ctx context.Context, ns *docker.Namespace, cmd *cobr
 		}
 	}
 
-	app, isNew, err := ns.DeployApplication(ctx, settings, progress)
-	if err != nil {
+	if err := app.Deploy(ctx, progress); err != nil {
+		if cleanupErr := app.Destroy(context.Background(), true); cleanupErr != nil {
+			slog.Error("Failed to clean up after deploy failure", "app", name, "error", cleanupErr)
+		}
 		return fmt.Errorf("%w: %w", docker.ErrDeployFailed, err)
 	}
 
-	if isNew {
-		fmt.Println("Verifying...")
-		if err := app.VerifyHTTPOrRemove(ctx); err != nil {
-			return err
-		}
+	fmt.Println("Verifying...")
+	if err := app.VerifyHTTPOrRemove(ctx); err != nil {
+		return err
 	}
 
-	fmt.Printf("Deployed %s\n", app.Settings.Name)
+	fmt.Printf("Deployed %s\n", name)
 	return nil
-}
-
-func (d *deployCommand) parseEnvVars() (map[string]string, error) {
-	if d.env == nil {
-		return nil, nil
-	}
-
-	envVars := make(map[string]string, len(d.env))
-	for _, e := range d.env {
-		key, value, ok := strings.Cut(e, "=")
-		if !ok {
-			return nil, fmt.Errorf("invalid environment variable %q: must be in KEY=VALUE format", e)
-		}
-		if key == "" {
-			return nil, fmt.Errorf("invalid environment variable %q: key must not be empty", e)
-		}
-		envVars[key] = value
-	}
-
-	return envVars, nil
 }

--- a/internal/command/deploy_test.go
+++ b/internal/command/deploy_test.go
@@ -5,6 +5,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/basecamp/once/internal/docker"
 )
 
 func TestParseEnvVars(t *testing.T) {
@@ -53,5 +55,19 @@ func TestParseEnvVars(t *testing.T) {
 		result, err := f.parseEnvVars()
 		require.NoError(t, err)
 		assert.Equal(t, "second", result["KEY"])
+	})
+}
+
+func TestBuildSettingsAutoBackupRequiresPath(t *testing.T) {
+	t.Run("auto-backup without path", func(t *testing.T) {
+		f := &settingsFlags{autoBackup: true}
+		_, err := f.buildSettings("image:latest", "app.example.com")
+		assert.ErrorIs(t, err, docker.ErrAutoBackupWithoutPath)
+	})
+
+	t.Run("auto-backup with path", func(t *testing.T) {
+		f := &settingsFlags{autoBackup: true, backupPath: "/backups"}
+		_, err := f.buildSettings("image:latest", "app.example.com")
+		require.NoError(t, err)
 	})
 }

--- a/internal/command/deploy_test.go
+++ b/internal/command/deploy_test.go
@@ -1,0 +1,57 @@
+package command
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseEnvVars(t *testing.T) {
+	t.Run("nil input", func(t *testing.T) {
+		d := &deployCommand{}
+		result, err := d.parseEnvVars()
+		require.NoError(t, err)
+		assert.Nil(t, result)
+	})
+
+	t.Run("valid pairs", func(t *testing.T) {
+		d := &deployCommand{env: []string{"FOO=bar", "BAZ=qux"}}
+		result, err := d.parseEnvVars()
+		require.NoError(t, err)
+		assert.Equal(t, map[string]string{"FOO": "bar", "BAZ": "qux"}, result)
+	})
+
+	t.Run("value containing equals", func(t *testing.T) {
+		d := &deployCommand{env: []string{"DSN=postgres://host?opt=val"}}
+		result, err := d.parseEnvVars()
+		require.NoError(t, err)
+		assert.Equal(t, "postgres://host?opt=val", result["DSN"])
+	})
+
+	t.Run("missing equals", func(t *testing.T) {
+		d := &deployCommand{env: []string{"INVALID"}}
+		_, err := d.parseEnvVars()
+		assert.ErrorContains(t, err, "must be in KEY=VALUE format")
+	})
+
+	t.Run("empty key", func(t *testing.T) {
+		d := &deployCommand{env: []string{"=value"}}
+		_, err := d.parseEnvVars()
+		assert.ErrorContains(t, err, "key must not be empty")
+	})
+
+	t.Run("empty value is valid", func(t *testing.T) {
+		d := &deployCommand{env: []string{"KEY="}}
+		result, err := d.parseEnvVars()
+		require.NoError(t, err)
+		assert.Equal(t, "", result["KEY"])
+	})
+
+	t.Run("duplicate keys last wins", func(t *testing.T) {
+		d := &deployCommand{env: []string{"KEY=first", "KEY=second"}}
+		result, err := d.parseEnvVars()
+		require.NoError(t, err)
+		assert.Equal(t, "second", result["KEY"])
+	})
+}

--- a/internal/command/deploy_test.go
+++ b/internal/command/deploy_test.go
@@ -58,6 +58,12 @@ func TestParseEnvVars(t *testing.T) {
 	})
 }
 
+func TestBuildSettingsImageRequired(t *testing.T) {
+	f := &settingsFlags{}
+	_, err := f.buildSettings("", "app.example.com")
+	assert.ErrorIs(t, err, docker.ErrImageRequired)
+}
+
 func TestBuildSettingsAutoBackupRequiresPath(t *testing.T) {
 	t.Run("auto-backup without path", func(t *testing.T) {
 		f := &settingsFlags{autoBackup: true}

--- a/internal/command/deploy_test.go
+++ b/internal/command/deploy_test.go
@@ -9,48 +9,48 @@ import (
 
 func TestParseEnvVars(t *testing.T) {
 	t.Run("nil input", func(t *testing.T) {
-		d := &deployCommand{}
-		result, err := d.parseEnvVars()
+		f := &settingsFlags{}
+		result, err := f.parseEnvVars()
 		require.NoError(t, err)
 		assert.Nil(t, result)
 	})
 
 	t.Run("valid pairs", func(t *testing.T) {
-		d := &deployCommand{env: []string{"FOO=bar", "BAZ=qux"}}
-		result, err := d.parseEnvVars()
+		f := &settingsFlags{env: []string{"FOO=bar", "BAZ=qux"}}
+		result, err := f.parseEnvVars()
 		require.NoError(t, err)
 		assert.Equal(t, map[string]string{"FOO": "bar", "BAZ": "qux"}, result)
 	})
 
 	t.Run("value containing equals", func(t *testing.T) {
-		d := &deployCommand{env: []string{"DSN=postgres://host?opt=val"}}
-		result, err := d.parseEnvVars()
+		f := &settingsFlags{env: []string{"DSN=postgres://host?opt=val"}}
+		result, err := f.parseEnvVars()
 		require.NoError(t, err)
 		assert.Equal(t, "postgres://host?opt=val", result["DSN"])
 	})
 
 	t.Run("missing equals", func(t *testing.T) {
-		d := &deployCommand{env: []string{"INVALID"}}
-		_, err := d.parseEnvVars()
+		f := &settingsFlags{env: []string{"INVALID"}}
+		_, err := f.parseEnvVars()
 		assert.ErrorContains(t, err, "must be in KEY=VALUE format")
 	})
 
 	t.Run("empty key", func(t *testing.T) {
-		d := &deployCommand{env: []string{"=value"}}
-		_, err := d.parseEnvVars()
+		f := &settingsFlags{env: []string{"=value"}}
+		_, err := f.parseEnvVars()
 		assert.ErrorContains(t, err, "key must not be empty")
 	})
 
 	t.Run("empty value is valid", func(t *testing.T) {
-		d := &deployCommand{env: []string{"KEY="}}
-		result, err := d.parseEnvVars()
+		f := &settingsFlags{env: []string{"KEY="}}
+		result, err := f.parseEnvVars()
 		require.NoError(t, err)
 		assert.Equal(t, "", result["KEY"])
 	})
 
 	t.Run("duplicate keys last wins", func(t *testing.T) {
-		d := &deployCommand{env: []string{"KEY=first", "KEY=second"}}
-		result, err := d.parseEnvVars()
+		f := &settingsFlags{env: []string{"KEY=first", "KEY=second"}}
+		result, err := f.parseEnvVars()
 		require.NoError(t, err)
 		assert.Equal(t, "second", result["KEY"])
 	})

--- a/internal/command/list.go
+++ b/internal/command/list.go
@@ -4,10 +4,13 @@ import (
 	"context"
 	"fmt"
 
+	"charm.land/lipgloss/v2"
 	"github.com/spf13/cobra"
 
 	"github.com/basecamp/once/internal/docker"
 )
+
+var hostStyle = lipgloss.NewStyle().Foreground(lipgloss.BrightBlue)
 
 type listCommand struct {
 	cmd *cobra.Command
@@ -28,7 +31,14 @@ func newListCommand() *listCommand {
 
 func (l *listCommand) run(_ context.Context, ns *docker.Namespace, cmd *cobra.Command, args []string) error {
 	for _, app := range ns.Applications() {
-		fmt.Println(app.Settings.Name)
+		status := "stopped"
+		if app.Running {
+			status = "running"
+		}
+
+		host := hostStyle.Hyperlink(app.URL()).Render(app.Settings.Host)
+
+		fmt.Printf("%s (%s)\n", host, status)
 	}
 
 	return nil

--- a/internal/command/remove.go
+++ b/internal/command/remove.go
@@ -17,7 +17,7 @@ type removeCommand struct {
 func newRemoveCommand() *removeCommand {
 	r := &removeCommand{}
 	r.cmd = &cobra.Command{
-		Use:     "remove <app>",
+		Use:     "remove <host>",
 		Aliases: []string{"rm"},
 		Short:   "Remove an application",
 		Args:    cobra.ExactArgs(1),
@@ -30,15 +30,15 @@ func newRemoveCommand() *removeCommand {
 // Private
 
 func (r *removeCommand) run(ctx context.Context, ns *docker.Namespace, cmd *cobra.Command, args []string) error {
-	appName := args[0]
+	host := args[0]
 
-	err := withApplication(ns, appName, "removing", func(app *docker.Application) error {
+	err := withApplication(ns, host, "removing", func(app *docker.Application) error {
 		return app.Remove(ctx, r.removeData)
 	})
 	if err != nil {
 		return err
 	}
 
-	fmt.Printf("Removed %s\n", appName)
+	fmt.Printf("Removed %s\n", host)
 	return nil
 }

--- a/internal/command/root.go
+++ b/internal/command/root.go
@@ -61,10 +61,10 @@ func (r *RootCommand) Execute() error {
 
 type NamespaceRunE func(ctx context.Context, ns *docker.Namespace, cmd *cobra.Command, args []string) error
 
-func withApplication(ns *docker.Namespace, name string, action string, fn func(*docker.Application) error) error {
-	app := ns.Application(name)
+func withApplication(ns *docker.Namespace, host string, action string, fn func(*docker.Application) error) error {
+	app := ns.ApplicationByHost(host)
 	if app == nil {
-		return fmt.Errorf("application %q not found", name)
+		return fmt.Errorf("no application found at host %q", host)
 	}
 
 	if err := fn(app); err != nil {

--- a/internal/command/root.go
+++ b/internal/command/root.go
@@ -47,6 +47,7 @@ func NewRootCommand() *RootCommand {
 	r.cmd.AddCommand(newStopCommand().cmd)
 	r.cmd.AddCommand(newTeardownCommand().cmd)
 	r.cmd.AddCommand(newUpdateCommand().cmd)
+	r.cmd.AddCommand(newSelfUpdateCommand().cmd)
 	r.cmd.AddCommand(newVersionCommand().cmd)
 
 	return r

--- a/internal/command/root_test.go
+++ b/internal/command/root_test.go
@@ -11,12 +11,12 @@ import (
 
 func TestWithApplicationFound(t *testing.T) {
 	ns, err := docker.NewNamespace("test", docker.WithApplications(
-		docker.ApplicationSettings{Name: "myapp"},
+		docker.ApplicationSettings{Name: "myapp", Host: "myapp.localhost"},
 	))
 	require.NoError(t, err)
 
 	var called bool
-	err = withApplication(ns, "myapp", "testing", func(app *docker.Application) error {
+	err = withApplication(ns, "myapp.localhost", "testing", func(app *docker.Application) error {
 		called = true
 		assert.Equal(t, "myapp", app.Settings.Name)
 		return nil
@@ -30,22 +30,22 @@ func TestWithApplicationNotFound(t *testing.T) {
 	ns, err := docker.NewNamespace("test")
 	require.NoError(t, err)
 
-	err = withApplication(ns, "missing", "testing", func(app *docker.Application) error {
+	err = withApplication(ns, "missing.localhost", "testing", func(app *docker.Application) error {
 		t.Fatal("should not be called")
 		return nil
 	})
 
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), `application "missing" not found`)
+	assert.Contains(t, err.Error(), `no application found at host "missing.localhost"`)
 }
 
 func TestWithApplicationError(t *testing.T) {
 	ns, err := docker.NewNamespace("test", docker.WithApplications(
-		docker.ApplicationSettings{Name: "myapp"},
+		docker.ApplicationSettings{Name: "myapp", Host: "myapp.localhost"},
 	))
 	require.NoError(t, err)
 
-	err = withApplication(ns, "myapp", "starting", func(app *docker.Application) error {
+	err = withApplication(ns, "myapp.localhost", "starting", func(app *docker.Application) error {
 		return assert.AnError
 	})
 

--- a/internal/command/self_update.go
+++ b/internal/command/self_update.go
@@ -1,0 +1,24 @@
+package command
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/basecamp/once/internal/version"
+)
+
+type selfUpdateCommand struct {
+	cmd *cobra.Command
+}
+
+func newSelfUpdateCommand() *selfUpdateCommand {
+	u := &selfUpdateCommand{}
+	u.cmd = &cobra.Command{
+		Use:   "self-update",
+		Short: "Update once to the latest version",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return version.NewUpdater().UpdateBinary()
+		},
+	}
+	return u
+}

--- a/internal/command/settings_flags.go
+++ b/internal/command/settings_flags.go
@@ -52,7 +52,7 @@ func (f *settingsFlags) buildSettings(image, host string) (docker.ApplicationSet
 		return docker.ApplicationSettings{}, docker.ErrBackupPathRelative
 	}
 
-	return docker.ApplicationSettings{
+	s := docker.ApplicationSettings{
 		Image:      image,
 		Host:       host,
 		DisableTLS: f.disableTLS,
@@ -73,7 +73,13 @@ func (f *settingsFlags) buildSettings(image, host string) (docker.ApplicationSet
 			Path:       f.backupPath,
 			AutoBackup: f.autoBackup,
 		},
-	}, nil
+	}
+
+	if err := s.Validate(); err != nil {
+		return docker.ApplicationSettings{}, err
+	}
+
+	return s, nil
 }
 
 func (f *settingsFlags) applyChanges(cmd *cobra.Command, existing docker.ApplicationSettings) (docker.ApplicationSettings, error) {
@@ -124,6 +130,10 @@ func (f *settingsFlags) applyChanges(cmd *cobra.Command, existing docker.Applica
 	}
 	if cmd.Flags().Changed("auto-backup") {
 		s.Backup.AutoBackup = f.autoBackup
+	}
+
+	if err := s.Validate(); err != nil {
+		return s, err
 	}
 
 	return s, nil

--- a/internal/command/settings_flags.go
+++ b/internal/command/settings_flags.go
@@ -82,8 +82,10 @@ func (f *settingsFlags) buildSettings(image, host string) (docker.ApplicationSet
 	return s, nil
 }
 
-func (f *settingsFlags) applyChanges(cmd *cobra.Command, existing docker.ApplicationSettings) (docker.ApplicationSettings, error) {
+func (f *settingsFlags) applyChanges(cmd *cobra.Command, existing docker.ApplicationSettings, image string) (docker.ApplicationSettings, error) {
 	s := existing
+
+	s.Image = image
 
 	if cmd.Flags().Changed("host") {
 		s.Host = f.host

--- a/internal/command/settings_flags.go
+++ b/internal/command/settings_flags.go
@@ -1,0 +1,142 @@
+package command
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/basecamp/once/internal/docker"
+)
+
+type settingsFlags struct {
+	host         string
+	disableTLS   bool
+	env          []string
+	smtpServer   string
+	smtpPort     string
+	smtpUsername string
+	smtpPassword string
+	smtpFrom     string
+	cpus         int
+	memory       int
+	autoUpdate   bool
+	backupPath   string
+	autoBackup   bool
+}
+
+func (f *settingsFlags) register(cmd *cobra.Command) {
+	cmd.Flags().StringVar(&f.host, "host", "", "hostname for the application")
+	cmd.Flags().BoolVar(&f.disableTLS, "disable-tls", false, "disable TLS for this application")
+	cmd.Flags().StringArrayVar(&f.env, "env", nil, "environment variable in KEY=VALUE format (can be repeated)")
+	cmd.Flags().StringVar(&f.smtpServer, "smtp-server", "", "SMTP server address")
+	cmd.Flags().StringVar(&f.smtpPort, "smtp-port", "", "SMTP server port")
+	cmd.Flags().StringVar(&f.smtpUsername, "smtp-username", "", "SMTP username")
+	cmd.Flags().StringVar(&f.smtpPassword, "smtp-password", "", "SMTP password")
+	cmd.Flags().StringVar(&f.smtpFrom, "smtp-from", "", "SMTP from address")
+	cmd.Flags().IntVar(&f.cpus, "cpus", 0, "CPU limit for the container")
+	cmd.Flags().IntVar(&f.memory, "memory", 0, "memory limit in MB for the container")
+	cmd.Flags().BoolVar(&f.autoUpdate, "auto-update", true, "automatically update the application")
+	cmd.Flags().StringVar(&f.backupPath, "backup-path", "", "path for backups")
+	cmd.Flags().BoolVar(&f.autoBackup, "auto-backup", false, "enable automatic backups")
+}
+
+func (f *settingsFlags) buildSettings(image, host string) (docker.ApplicationSettings, error) {
+	envVars, err := f.parseEnvVars()
+	if err != nil {
+		return docker.ApplicationSettings{}, err
+	}
+
+	return docker.ApplicationSettings{
+		Image:      image,
+		Host:       host,
+		DisableTLS: f.disableTLS,
+		EnvVars:    envVars,
+		SMTP: docker.SMTPSettings{
+			Server:   f.smtpServer,
+			Port:     f.smtpPort,
+			Username: f.smtpUsername,
+			Password: f.smtpPassword,
+			From:     f.smtpFrom,
+		},
+		Resources: docker.ContainerResources{
+			CPUs:     f.cpus,
+			MemoryMB: f.memory,
+		},
+		AutoUpdate: f.autoUpdate,
+		Backup: docker.BackupSettings{
+			Path:       f.backupPath,
+			AutoBackup: f.autoBackup,
+		},
+	}, nil
+}
+
+func (f *settingsFlags) applyChanges(cmd *cobra.Command, existing docker.ApplicationSettings) (docker.ApplicationSettings, error) {
+	s := existing
+
+	if cmd.Flags().Changed("host") {
+		s.Host = f.host
+	}
+	if cmd.Flags().Changed("disable-tls") {
+		s.DisableTLS = f.disableTLS
+	}
+	if cmd.Flags().Changed("env") {
+		envVars, err := f.parseEnvVars()
+		if err != nil {
+			return s, err
+		}
+		s.EnvVars = envVars
+	}
+	if cmd.Flags().Changed("smtp-server") {
+		s.SMTP.Server = f.smtpServer
+	}
+	if cmd.Flags().Changed("smtp-port") {
+		s.SMTP.Port = f.smtpPort
+	}
+	if cmd.Flags().Changed("smtp-username") {
+		s.SMTP.Username = f.smtpUsername
+	}
+	if cmd.Flags().Changed("smtp-password") {
+		s.SMTP.Password = f.smtpPassword
+	}
+	if cmd.Flags().Changed("smtp-from") {
+		s.SMTP.From = f.smtpFrom
+	}
+	if cmd.Flags().Changed("cpus") {
+		s.Resources.CPUs = f.cpus
+	}
+	if cmd.Flags().Changed("memory") {
+		s.Resources.MemoryMB = f.memory
+	}
+	if cmd.Flags().Changed("auto-update") {
+		s.AutoUpdate = f.autoUpdate
+	}
+	if cmd.Flags().Changed("backup-path") {
+		s.Backup.Path = f.backupPath
+	}
+	if cmd.Flags().Changed("auto-backup") {
+		s.Backup.AutoBackup = f.autoBackup
+	}
+
+	return s, nil
+}
+
+func (f *settingsFlags) parseEnvVars() (map[string]string, error) {
+	if f.env == nil {
+		return nil, nil
+	}
+
+	envVars := make(map[string]string, len(f.env))
+	for _, e := range f.env {
+		key, value, ok := strings.Cut(e, "=")
+		if !ok {
+			return nil, fmt.Errorf("invalid environment variable %q: must be in KEY=VALUE format", e)
+		}
+		if key == "" {
+			return nil, fmt.Errorf("invalid environment variable %q: key must not be empty", e)
+		}
+		envVars[key] = value
+	}
+
+	return envVars, nil
+}

--- a/internal/command/settings_flags.go
+++ b/internal/command/settings_flags.go
@@ -2,6 +2,7 @@ package command
 
 import (
 	"fmt"
+	"path/filepath"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -45,6 +46,10 @@ func (f *settingsFlags) buildSettings(image, host string) (docker.ApplicationSet
 	envVars, err := f.parseEnvVars()
 	if err != nil {
 		return docker.ApplicationSettings{}, err
+	}
+
+	if f.backupPath != "" && !filepath.IsAbs(f.backupPath) {
+		return docker.ApplicationSettings{}, docker.ErrBackupPathRelative
 	}
 
 	return docker.ApplicationSettings{
@@ -112,6 +117,9 @@ func (f *settingsFlags) applyChanges(cmd *cobra.Command, existing docker.Applica
 		s.AutoUpdate = f.autoUpdate
 	}
 	if cmd.Flags().Changed("backup-path") {
+		if f.backupPath != "" && !filepath.IsAbs(f.backupPath) {
+			return s, docker.ErrBackupPathRelative
+		}
 		s.Backup.Path = f.backupPath
 	}
 	if cmd.Flags().Changed("auto-backup") {

--- a/internal/command/start.go
+++ b/internal/command/start.go
@@ -16,7 +16,7 @@ type startCommand struct {
 func newStartCommand() *startCommand {
 	s := &startCommand{}
 	s.cmd = &cobra.Command{
-		Use:   "start <app>",
+		Use:   "start <host>",
 		Short: "Start an application",
 		Args:  cobra.ExactArgs(1),
 		RunE:  WithNamespace(s.run),
@@ -27,15 +27,15 @@ func newStartCommand() *startCommand {
 // Private
 
 func (s *startCommand) run(ctx context.Context, ns *docker.Namespace, cmd *cobra.Command, args []string) error {
-	appName := args[0]
+	host := args[0]
 
-	err := withApplication(ns, appName, "starting", func(app *docker.Application) error {
+	err := withApplication(ns, host, "starting", func(app *docker.Application) error {
 		return app.Start(ctx)
 	})
 	if err != nil {
 		return err
 	}
 
-	fmt.Printf("Started %s\n", appName)
+	fmt.Printf("Started %s\n", host)
 	return nil
 }

--- a/internal/command/stop.go
+++ b/internal/command/stop.go
@@ -16,7 +16,7 @@ type stopCommand struct {
 func newStopCommand() *stopCommand {
 	s := &stopCommand{}
 	s.cmd = &cobra.Command{
-		Use:   "stop <app>",
+		Use:   "stop <host>",
 		Short: "Stop an application",
 		Args:  cobra.ExactArgs(1),
 		RunE:  WithNamespace(s.run),
@@ -27,15 +27,15 @@ func newStopCommand() *stopCommand {
 // Private
 
 func (s *stopCommand) run(ctx context.Context, ns *docker.Namespace, cmd *cobra.Command, args []string) error {
-	appName := args[0]
+	host := args[0]
 
-	err := withApplication(ns, appName, "stopping", func(app *docker.Application) error {
+	err := withApplication(ns, host, "stopping", func(app *docker.Application) error {
 		return app.Stop(ctx)
 	})
 	if err != nil {
 		return err
 	}
 
-	fmt.Printf("Stopped %s\n", appName)
+	fmt.Printf("Stopped %s\n", host)
 	return nil
 }

--- a/internal/command/update.go
+++ b/internal/command/update.go
@@ -44,13 +44,14 @@ func (u *updateCommand) run(ctx context.Context, ns *docker.Namespace, cmd *cobr
 		return fmt.Errorf("%w: %w", docker.ErrSetupFailed, err)
 	}
 
-	settings, err := u.flags.applyChanges(cmd, app.Settings)
-	if err != nil {
-		return err
+	image := app.Settings.Image
+	if cmd.Flags().Changed("image") {
+		image = u.image
 	}
 
-	if cmd.Flags().Changed("image") {
-		settings.Image = u.image
+	settings, err := u.flags.applyChanges(cmd, app.Settings, image)
+	if err != nil {
+		return err
 	}
 
 	if settings.Host != app.Settings.Host {

--- a/internal/command/update.go
+++ b/internal/command/update.go
@@ -62,22 +62,13 @@ func (u *updateCommand) run(ctx context.Context, ns *docker.Namespace, cmd *cobr
 	oldSettings := app.Settings
 	app.Settings = settings
 
-	progress := func(p docker.DeployProgress) {
-		switch p.Stage {
-		case docker.DeployStageDownloading:
-			fmt.Printf("Downloading: %d%%\n", p.Percentage)
-		case docker.DeployStageStarting:
-			fmt.Println("Starting...")
-		case docker.DeployStageFinished:
-			fmt.Println("Finished")
+	p := newCLIProgress("Updating "+currentHost, func(progress docker.DeployProgressCallback) error {
+		if err := app.Deploy(ctx, progress); err != nil {
+			app.Settings = oldSettings
+			return fmt.Errorf("%w: %w", docker.ErrDeployFailed, err)
 		}
-	}
+		return nil
+	})
 
-	if err := app.Deploy(ctx, progress); err != nil {
-		app.Settings = oldSettings
-		return fmt.Errorf("%w: %w", docker.ErrDeployFailed, err)
-	}
-
-	fmt.Printf("Updated %s\n", app.Settings.Name)
-	return nil
+	return p.Run()
 }

--- a/internal/command/update.go
+++ b/internal/command/update.go
@@ -1,24 +1,83 @@
 package command
 
 import (
+	"context"
+	"fmt"
+
 	"github.com/spf13/cobra"
 
-	"github.com/basecamp/once/internal/version"
+	"github.com/basecamp/once/internal/docker"
 )
 
 type updateCommand struct {
-	cmd *cobra.Command
+	cmd   *cobra.Command
+	flags settingsFlags
+	image string
 }
 
 func newUpdateCommand() *updateCommand {
 	u := &updateCommand{}
 	u.cmd = &cobra.Command{
-		Use:   "update",
-		Short: "Update once to the latest version",
-		Args:  cobra.NoArgs,
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return version.NewUpdater().UpdateBinary()
-		},
+		Use:   "update <host>",
+		Short: "Update settings for a deployed application",
+		Args:  cobra.ExactArgs(1),
+		RunE:  WithNamespace(u.run),
 	}
+
+	u.flags.register(u.cmd)
+	u.cmd.Flags().StringVar(&u.image, "image", "", "new image for the application")
+
 	return u
+}
+
+// Private
+
+func (u *updateCommand) run(ctx context.Context, ns *docker.Namespace, cmd *cobra.Command, args []string) error {
+	currentHost := args[0]
+
+	app := ns.ApplicationByHost(currentHost)
+	if app == nil {
+		return fmt.Errorf("no application found at host %q", currentHost)
+	}
+
+	if err := ns.Setup(ctx); err != nil {
+		return fmt.Errorf("%w: %w", docker.ErrSetupFailed, err)
+	}
+
+	settings, err := u.flags.applyChanges(cmd, app.Settings)
+	if err != nil {
+		return err
+	}
+
+	if cmd.Flags().Changed("image") {
+		settings.Image = u.image
+	}
+
+	if settings.Host != app.Settings.Host {
+		if ns.HostInUseByAnother(settings.Host, app.Settings.Name) {
+			return docker.ErrHostnameInUse
+		}
+	}
+
+	oldSettings := app.Settings
+	app.Settings = settings
+
+	progress := func(p docker.DeployProgress) {
+		switch p.Stage {
+		case docker.DeployStageDownloading:
+			fmt.Printf("Downloading: %d%%\n", p.Percentage)
+		case docker.DeployStageStarting:
+			fmt.Println("Starting...")
+		case docker.DeployStageFinished:
+			fmt.Println("Finished")
+		}
+	}
+
+	if err := app.Deploy(ctx, progress); err != nil {
+		app.Settings = oldSettings
+		return fmt.Errorf("%w: %w", docker.ErrDeployFailed, err)
+	}
+
+	fmt.Printf("Updated %s\n", app.Settings.Name)
+	return nil
 }

--- a/internal/command/update_test.go
+++ b/internal/command/update_test.go
@@ -102,4 +102,54 @@ func TestApplyChanges(t *testing.T) {
 		_, err := f.applyChanges(cmd, existing)
 		assert.ErrorContains(t, err, "must be in KEY=VALUE format")
 	})
+
+	t.Run("enable auto-backup with existing path", func(t *testing.T) {
+		noAutoBackup := existing
+		noAutoBackup.Backup.AutoBackup = false
+
+		f := &settingsFlags{autoBackup: true}
+		cmd := newCmd()
+		require.NoError(t, cmd.Flags().Set("auto-backup", "true"))
+
+		result, err := f.applyChanges(cmd, noAutoBackup)
+		require.NoError(t, err)
+		assert.True(t, result.Backup.AutoBackup)
+	})
+
+	t.Run("enable auto-backup without path", func(t *testing.T) {
+		noPath := existing
+		noPath.Backup.Path = ""
+		noPath.Backup.AutoBackup = false
+
+		f := &settingsFlags{autoBackup: true}
+		cmd := newCmd()
+		require.NoError(t, cmd.Flags().Set("auto-backup", "true"))
+
+		_, err := f.applyChanges(cmd, noPath)
+		assert.ErrorIs(t, err, docker.ErrAutoBackupWithoutPath)
+	})
+
+	t.Run("clear backup path with auto-backup enabled", func(t *testing.T) {
+		f := &settingsFlags{backupPath: ""}
+		cmd := newCmd()
+		require.NoError(t, cmd.Flags().Set("backup-path", ""))
+
+		_, err := f.applyChanges(cmd, existing)
+		assert.ErrorIs(t, err, docker.ErrAutoBackupWithoutPath)
+	})
+
+	t.Run("set both auto-backup and path", func(t *testing.T) {
+		noBackup := existing
+		noBackup.Backup = docker.BackupSettings{}
+
+		f := &settingsFlags{autoBackup: true, backupPath: "/backups"}
+		cmd := newCmd()
+		require.NoError(t, cmd.Flags().Set("auto-backup", "true"))
+		require.NoError(t, cmd.Flags().Set("backup-path", "/backups"))
+
+		result, err := f.applyChanges(cmd, noBackup)
+		require.NoError(t, err)
+		assert.True(t, result.Backup.AutoBackup)
+		assert.Equal(t, "/backups", result.Backup.Path)
+	})
 }

--- a/internal/command/update_test.go
+++ b/internal/command/update_test.go
@@ -48,7 +48,7 @@ func TestApplyChanges(t *testing.T) {
 	t.Run("no flags changed returns existing", func(t *testing.T) {
 		f := &settingsFlags{}
 		cmd := newCmd()
-		result, err := f.applyChanges(cmd, existing)
+		result, err := f.applyChanges(cmd, existing, existing.Image)
 		require.NoError(t, err)
 		assert.True(t, existing.Equal(result))
 	})
@@ -58,7 +58,7 @@ func TestApplyChanges(t *testing.T) {
 		cmd := newCmd()
 		require.NoError(t, cmd.Flags().Set("memory", "2048"))
 
-		result, err := f.applyChanges(cmd, existing)
+		result, err := f.applyChanges(cmd, existing, existing.Image)
 		require.NoError(t, err)
 		assert.Equal(t, 2048, result.Resources.MemoryMB)
 		assert.Equal(t, existing.Resources.CPUs, result.Resources.CPUs)
@@ -73,7 +73,7 @@ func TestApplyChanges(t *testing.T) {
 		require.NoError(t, cmd.Flags().Set("cpus", "4"))
 		require.NoError(t, cmd.Flags().Set("auto-backup", "false"))
 
-		result, err := f.applyChanges(cmd, existing)
+		result, err := f.applyChanges(cmd, existing, existing.Image)
 		require.NoError(t, err)
 		assert.Equal(t, "new.example.com", result.Host)
 		assert.Equal(t, 4, result.Resources.CPUs)
@@ -89,7 +89,7 @@ func TestApplyChanges(t *testing.T) {
 		cmd := newCmd()
 		require.NoError(t, cmd.Flags().Set("env", "NEW=val"))
 
-		result, err := f.applyChanges(cmd, existing)
+		result, err := f.applyChanges(cmd, existing, existing.Image)
 		require.NoError(t, err)
 		assert.Equal(t, map[string]string{"NEW": "val"}, result.EnvVars)
 	})
@@ -99,8 +99,16 @@ func TestApplyChanges(t *testing.T) {
 		cmd := newCmd()
 		require.NoError(t, cmd.Flags().Set("env", "INVALID"))
 
-		_, err := f.applyChanges(cmd, existing)
+		_, err := f.applyChanges(cmd, existing, existing.Image)
 		assert.ErrorContains(t, err, "must be in KEY=VALUE format")
+	})
+
+	t.Run("empty image", func(t *testing.T) {
+		f := &settingsFlags{}
+		cmd := newCmd()
+
+		_, err := f.applyChanges(cmd, existing, "")
+		assert.ErrorIs(t, err, docker.ErrImageRequired)
 	})
 
 	t.Run("enable auto-backup with existing path", func(t *testing.T) {
@@ -111,7 +119,7 @@ func TestApplyChanges(t *testing.T) {
 		cmd := newCmd()
 		require.NoError(t, cmd.Flags().Set("auto-backup", "true"))
 
-		result, err := f.applyChanges(cmd, noAutoBackup)
+		result, err := f.applyChanges(cmd, noAutoBackup, noAutoBackup.Image)
 		require.NoError(t, err)
 		assert.True(t, result.Backup.AutoBackup)
 	})
@@ -125,7 +133,7 @@ func TestApplyChanges(t *testing.T) {
 		cmd := newCmd()
 		require.NoError(t, cmd.Flags().Set("auto-backup", "true"))
 
-		_, err := f.applyChanges(cmd, noPath)
+		_, err := f.applyChanges(cmd, noPath, noPath.Image)
 		assert.ErrorIs(t, err, docker.ErrAutoBackupWithoutPath)
 	})
 
@@ -134,7 +142,7 @@ func TestApplyChanges(t *testing.T) {
 		cmd := newCmd()
 		require.NoError(t, cmd.Flags().Set("backup-path", ""))
 
-		_, err := f.applyChanges(cmd, existing)
+		_, err := f.applyChanges(cmd, existing, existing.Image)
 		assert.ErrorIs(t, err, docker.ErrAutoBackupWithoutPath)
 	})
 
@@ -147,7 +155,7 @@ func TestApplyChanges(t *testing.T) {
 		require.NoError(t, cmd.Flags().Set("auto-backup", "true"))
 		require.NoError(t, cmd.Flags().Set("backup-path", "/backups"))
 
-		result, err := f.applyChanges(cmd, noBackup)
+		result, err := f.applyChanges(cmd, noBackup, noBackup.Image)
 		require.NoError(t, err)
 		assert.True(t, result.Backup.AutoBackup)
 		assert.Equal(t, "/backups", result.Backup.Path)

--- a/internal/command/update_test.go
+++ b/internal/command/update_test.go
@@ -1,0 +1,105 @@
+package command
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/basecamp/once/internal/docker"
+)
+
+func TestApplyChanges(t *testing.T) {
+	existing := docker.ApplicationSettings{
+		Name:       "myapp",
+		Image:      "myimage:latest",
+		Host:       "app.example.com",
+		DisableTLS: false,
+		EnvVars:    map[string]string{"KEY": "value"},
+		SMTP: docker.SMTPSettings{
+			Server:   "smtp.example.com",
+			Port:     "587",
+			Username: "user",
+			Password: "pass",
+			From:     "noreply@example.com",
+		},
+		Resources: docker.ContainerResources{
+			CPUs:     2,
+			MemoryMB: 1024,
+		},
+		AutoUpdate: true,
+		Backup: docker.BackupSettings{
+			Path:       "/backups",
+			AutoBackup: true,
+		},
+	}
+
+	newCmd := func(changed ...string) *cobra.Command {
+		cmd := &cobra.Command{}
+		f := &settingsFlags{}
+		f.register(cmd)
+		for _, name := range changed {
+			require.NoError(t, cmd.Flags().Set(name, cmd.Flags().Lookup(name).DefValue))
+		}
+		return cmd
+	}
+
+	t.Run("no flags changed returns existing", func(t *testing.T) {
+		f := &settingsFlags{}
+		cmd := newCmd()
+		result, err := f.applyChanges(cmd, existing)
+		require.NoError(t, err)
+		assert.True(t, existing.Equal(result))
+	})
+
+	t.Run("single flag changed", func(t *testing.T) {
+		f := &settingsFlags{memory: 2048}
+		cmd := newCmd()
+		require.NoError(t, cmd.Flags().Set("memory", "2048"))
+
+		result, err := f.applyChanges(cmd, existing)
+		require.NoError(t, err)
+		assert.Equal(t, 2048, result.Resources.MemoryMB)
+		assert.Equal(t, existing.Resources.CPUs, result.Resources.CPUs)
+		assert.Equal(t, existing.Host, result.Host)
+		assert.Equal(t, existing.EnvVars, result.EnvVars)
+	})
+
+	t.Run("multiple flags changed", func(t *testing.T) {
+		f := &settingsFlags{host: "new.example.com", cpus: 4, autoBackup: false}
+		cmd := newCmd()
+		require.NoError(t, cmd.Flags().Set("host", "new.example.com"))
+		require.NoError(t, cmd.Flags().Set("cpus", "4"))
+		require.NoError(t, cmd.Flags().Set("auto-backup", "false"))
+
+		result, err := f.applyChanges(cmd, existing)
+		require.NoError(t, err)
+		assert.Equal(t, "new.example.com", result.Host)
+		assert.Equal(t, 4, result.Resources.CPUs)
+		assert.Equal(t, false, result.Backup.AutoBackup)
+		// Unchanged fields preserved
+		assert.Equal(t, existing.SMTP, result.SMTP)
+		assert.Equal(t, existing.EnvVars, result.EnvVars)
+		assert.Equal(t, existing.Resources.MemoryMB, result.Resources.MemoryMB)
+	})
+
+	t.Run("env replaces all vars", func(t *testing.T) {
+		f := &settingsFlags{env: []string{"NEW=val"}}
+		cmd := newCmd()
+		require.NoError(t, cmd.Flags().Set("env", "NEW=val"))
+
+		result, err := f.applyChanges(cmd, existing)
+		require.NoError(t, err)
+		assert.Equal(t, map[string]string{"NEW": "val"}, result.EnvVars)
+	})
+
+	t.Run("invalid env returns error", func(t *testing.T) {
+		f := &settingsFlags{env: []string{"INVALID"}}
+		cmd := newCmd()
+		require.NoError(t, cmd.Flags().Set("env", "INVALID"))
+
+		_, err := f.applyChanges(cmd, existing)
+		assert.ErrorContains(t, err, "must be in KEY=VALUE format")
+	})
+}

--- a/internal/command/update_test.go
+++ b/internal/command/update_test.go
@@ -35,27 +35,22 @@ func TestApplyChanges(t *testing.T) {
 		},
 	}
 
-	newCmd := func(changed ...string) *cobra.Command {
+	newCmd := func() (*cobra.Command, *settingsFlags) {
 		cmd := &cobra.Command{}
 		f := &settingsFlags{}
 		f.register(cmd)
-		for _, name := range changed {
-			require.NoError(t, cmd.Flags().Set(name, cmd.Flags().Lookup(name).DefValue))
-		}
-		return cmd
+		return cmd, f
 	}
 
 	t.Run("no flags changed returns existing", func(t *testing.T) {
-		f := &settingsFlags{}
-		cmd := newCmd()
+		cmd, f := newCmd()
 		result, err := f.applyChanges(cmd, existing, existing.Image)
 		require.NoError(t, err)
 		assert.True(t, existing.Equal(result))
 	})
 
 	t.Run("single flag changed", func(t *testing.T) {
-		f := &settingsFlags{memory: 2048}
-		cmd := newCmd()
+		cmd, f := newCmd()
 		require.NoError(t, cmd.Flags().Set("memory", "2048"))
 
 		result, err := f.applyChanges(cmd, existing, existing.Image)
@@ -67,8 +62,7 @@ func TestApplyChanges(t *testing.T) {
 	})
 
 	t.Run("multiple flags changed", func(t *testing.T) {
-		f := &settingsFlags{host: "new.example.com", cpus: 4, autoBackup: false}
-		cmd := newCmd()
+		cmd, f := newCmd()
 		require.NoError(t, cmd.Flags().Set("host", "new.example.com"))
 		require.NoError(t, cmd.Flags().Set("cpus", "4"))
 		require.NoError(t, cmd.Flags().Set("auto-backup", "false"))
@@ -85,8 +79,7 @@ func TestApplyChanges(t *testing.T) {
 	})
 
 	t.Run("env replaces all vars", func(t *testing.T) {
-		f := &settingsFlags{env: []string{"NEW=val"}}
-		cmd := newCmd()
+		cmd, f := newCmd()
 		require.NoError(t, cmd.Flags().Set("env", "NEW=val"))
 
 		result, err := f.applyChanges(cmd, existing, existing.Image)
@@ -95,8 +88,7 @@ func TestApplyChanges(t *testing.T) {
 	})
 
 	t.Run("invalid env returns error", func(t *testing.T) {
-		f := &settingsFlags{env: []string{"INVALID"}}
-		cmd := newCmd()
+		cmd, f := newCmd()
 		require.NoError(t, cmd.Flags().Set("env", "INVALID"))
 
 		_, err := f.applyChanges(cmd, existing, existing.Image)
@@ -104,8 +96,7 @@ func TestApplyChanges(t *testing.T) {
 	})
 
 	t.Run("empty image", func(t *testing.T) {
-		f := &settingsFlags{}
-		cmd := newCmd()
+		cmd, f := newCmd()
 
 		_, err := f.applyChanges(cmd, existing, "")
 		assert.ErrorIs(t, err, docker.ErrImageRequired)
@@ -115,8 +106,7 @@ func TestApplyChanges(t *testing.T) {
 		noAutoBackup := existing
 		noAutoBackup.Backup.AutoBackup = false
 
-		f := &settingsFlags{autoBackup: true}
-		cmd := newCmd()
+		cmd, f := newCmd()
 		require.NoError(t, cmd.Flags().Set("auto-backup", "true"))
 
 		result, err := f.applyChanges(cmd, noAutoBackup, noAutoBackup.Image)
@@ -129,8 +119,7 @@ func TestApplyChanges(t *testing.T) {
 		noPath.Backup.Path = ""
 		noPath.Backup.AutoBackup = false
 
-		f := &settingsFlags{autoBackup: true}
-		cmd := newCmd()
+		cmd, f := newCmd()
 		require.NoError(t, cmd.Flags().Set("auto-backup", "true"))
 
 		_, err := f.applyChanges(cmd, noPath, noPath.Image)
@@ -138,8 +127,7 @@ func TestApplyChanges(t *testing.T) {
 	})
 
 	t.Run("clear backup path with auto-backup enabled", func(t *testing.T) {
-		f := &settingsFlags{backupPath: ""}
-		cmd := newCmd()
+		cmd, f := newCmd()
 		require.NoError(t, cmd.Flags().Set("backup-path", ""))
 
 		_, err := f.applyChanges(cmd, existing, existing.Image)
@@ -150,8 +138,7 @@ func TestApplyChanges(t *testing.T) {
 		noBackup := existing
 		noBackup.Backup = docker.BackupSettings{}
 
-		f := &settingsFlags{autoBackup: true, backupPath: "/backups"}
-		cmd := newCmd()
+		cmd, f := newCmd()
 		require.NoError(t, cmd.Flags().Set("auto-backup", "true"))
 		require.NoError(t, cmd.Flags().Set("backup-path", "/backups"))
 

--- a/internal/docker/application.go
+++ b/internal/docker/application.go
@@ -22,7 +22,8 @@ var (
 	ErrHostnameInUse      = errors.New("hostname already in use")
 	ErrHostRequired       = errors.New("host is required")
 	ErrInvalidBackup      = errors.New("invalid backup archive")
-	ErrBackupPathRelative = errors.New("backup path must be absolute")
+	ErrBackupPathRelative    = errors.New("backup path must be absolute")
+	ErrAutoBackupWithoutPath = errors.New("auto-backup requires a backup path")
 	ErrSetupFailed        = errors.New("setup failed")
 	ErrPullFailed         = &describedError{
 		msg:         "pull failed",

--- a/internal/docker/application.go
+++ b/internal/docker/application.go
@@ -22,6 +22,7 @@ var (
 	ErrHostnameInUse      = errors.New("hostname already in use")
 	ErrHostRequired       = errors.New("host is required")
 	ErrInvalidBackup      = errors.New("invalid backup archive")
+	ErrImageRequired         = errors.New("image is required")
 	ErrBackupPathRelative    = errors.New("backup path must be absolute")
 	ErrAutoBackupWithoutPath = errors.New("auto-backup requires a backup path")
 	ErrSetupFailed        = errors.New("setup failed")

--- a/internal/docker/application_settings.go
+++ b/internal/docker/application_settings.go
@@ -60,6 +60,9 @@ func (s ApplicationSettings) Marshal() string {
 }
 
 func (s ApplicationSettings) Validate() error {
+	if s.Image == "" {
+		return ErrImageRequired
+	}
 	if s.Backup.AutoBackup && s.Backup.Path == "" {
 		return ErrAutoBackupWithoutPath
 	}

--- a/internal/docker/application_settings.go
+++ b/internal/docker/application_settings.go
@@ -59,6 +59,13 @@ func (s ApplicationSettings) Marshal() string {
 	return string(b)
 }
 
+func (s ApplicationSettings) Validate() error {
+	if s.Backup.AutoBackup && s.Backup.Path == "" {
+		return ErrAutoBackupWithoutPath
+	}
+	return nil
+}
+
 func (s ApplicationSettings) TLSEnabled() bool {
 	return s.Host != "" && !s.DisableTLS && !IsLocalhost(s.Host)
 }

--- a/internal/docker/namespace.go
+++ b/internal/docker/namespace.go
@@ -108,13 +108,17 @@ func (n *Namespace) Applications() []*Application {
 	return n.applications
 }
 
-func (n *Namespace) HostInUse(host string) bool {
+func (n *Namespace) ApplicationByHost(host string) *Application {
 	for _, app := range n.applications {
 		if app.Settings.Host == host {
-			return true
+			return app
 		}
 	}
-	return false
+	return nil
+}
+
+func (n *Namespace) HostInUse(host string) bool {
+	return n.ApplicationByHost(host) != nil
 }
 
 func (n *Namespace) HostInUseByAnother(host string, excludeApp string) bool {
@@ -145,6 +149,43 @@ func (n *Namespace) Setup(ctx context.Context) error {
 	}
 
 	return n.proxy.Boot(ctx, ProxySettings{})
+}
+
+// DeployApplication deploys an application, reusing an existing app if the host
+// is already in use. It returns the app, whether it was a fresh deploy, and any
+// error. On redeploy failure, the existing app's settings are restored.
+//
+// This method does not update the namespace's application list for fresh
+// deploys. Callers should call Refresh if they need the namespace to reflect the
+// new app.
+func (n *Namespace) DeployApplication(ctx context.Context, settings ApplicationSettings, progress DeployProgressCallback) (*Application, bool, error) {
+	if existing := n.ApplicationByHost(settings.Host); existing != nil {
+		oldSettings := existing.Settings
+		settings.Name = oldSettings.Name
+		existing.Settings = settings
+		if err := existing.Deploy(ctx, progress); err != nil {
+			existing.Settings = oldSettings
+			return nil, false, err
+		}
+		return existing, false, nil
+	}
+
+	baseName := NameFromImageRef(settings.Image)
+	name, err := n.UniqueName(baseName)
+	if err != nil {
+		return nil, false, fmt.Errorf("generating app name: %w", err)
+	}
+	settings.Name = name
+
+	app := NewApplication(n, settings)
+	if err := app.Deploy(ctx, progress); err != nil {
+		if cleanupErr := app.Destroy(context.Background(), true); cleanupErr != nil {
+			slog.Error("Failed to clean up after deploy failure", "app", name, "error", cleanupErr)
+		}
+		return nil, true, err
+	}
+
+	return app, true, nil
 }
 
 func (n *Namespace) EnsureNetwork(ctx context.Context) error {

--- a/internal/docker/namespace.go
+++ b/internal/docker/namespace.go
@@ -151,43 +151,6 @@ func (n *Namespace) Setup(ctx context.Context) error {
 	return n.proxy.Boot(ctx, ProxySettings{})
 }
 
-// DeployApplication deploys an application, reusing an existing app if the host
-// is already in use. It returns the app, whether it was a fresh deploy, and any
-// error. On redeploy failure, the existing app's settings are restored.
-//
-// This method does not update the namespace's application list for fresh
-// deploys. Callers should call Refresh if they need the namespace to reflect the
-// new app.
-func (n *Namespace) DeployApplication(ctx context.Context, settings ApplicationSettings, progress DeployProgressCallback) (*Application, bool, error) {
-	if existing := n.ApplicationByHost(settings.Host); existing != nil {
-		oldSettings := existing.Settings
-		settings.Name = oldSettings.Name
-		existing.Settings = settings
-		if err := existing.Deploy(ctx, progress); err != nil {
-			existing.Settings = oldSettings
-			return nil, false, err
-		}
-		return existing, false, nil
-	}
-
-	baseName := NameFromImageRef(settings.Image)
-	name, err := n.UniqueName(baseName)
-	if err != nil {
-		return nil, false, fmt.Errorf("generating app name: %w", err)
-	}
-	settings.Name = name
-
-	app := NewApplication(n, settings)
-	if err := app.Deploy(ctx, progress); err != nil {
-		if cleanupErr := app.Destroy(context.Background(), true); cleanupErr != nil {
-			slog.Error("Failed to clean up after deploy failure", "app", name, "error", cleanupErr)
-		}
-		return nil, true, err
-	}
-
-	return app, true, nil
-}
-
 func (n *Namespace) EnsureNetwork(ctx context.Context) error {
 	networks, err := n.client.NetworkList(ctx, network.ListOptions{})
 	if err != nil {

--- a/internal/docker/namespace_test.go
+++ b/internal/docker/namespace_test.go
@@ -32,6 +32,24 @@ func TestApplicationLookup(t *testing.T) {
 	assert.Nil(t, ns.Application("missing"))
 }
 
+func TestApplicationByHost(t *testing.T) {
+	ns := &Namespace{name: "test"}
+	ns.applications = append(ns.applications,
+		NewApplication(ns, ApplicationSettings{Name: "app1", Host: "app1.localhost"}),
+		NewApplication(ns, ApplicationSettings{Name: "app2", Host: "app2.localhost"}),
+	)
+
+	app := ns.ApplicationByHost("app1.localhost")
+	require.NotNil(t, app)
+	assert.Equal(t, "app1", app.Settings.Name)
+
+	app = ns.ApplicationByHost("app2.localhost")
+	require.NotNil(t, app)
+	assert.Equal(t, "app2", app.Settings.Name)
+
+	assert.Nil(t, ns.ApplicationByHost("missing.localhost"))
+}
+
 func TestHostInUse(t *testing.T) {
 	ns := &Namespace{name: "test"}
 	ns.applications = append(ns.applications,


### PR DESCRIPTION
Improve the CLI interactions:

- Rename self update command to "once self-update"
- Add a "once update" for updating an existing application
- Both `deploy` and `update` now support flags for all settings: env vars, CPU/memory quota, backup options, etc
- Make the output of `deploy`, `update` and `list` look nicer
- Change commands to expect hostname as app identifier, rather than our internal name

![cli](https://github.com/user-attachments/assets/00f9973a-692d-4f02-83ec-02f7b4107739)
