### PR TITLE
Allow turning off starfield/logo animation

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,14 @@ curl https://get.once.com | sh
 This will download the appropriate binary for your platform, install it and its corresponding background service, and then launch it so you can do your first application install.
 If the machine you're running this from doesn't already have Docker, it will install that too (on supported platforms).
 
+### Customizing the installer behaviour
+
+If you want to install `once` without launching it (for example, for a scripted install), you can use `ONCE_INTERACTIVE=false`:
+
+```sh
+curl https://get.once.com | ONCE_INTERACTIVE=false sh
+```
+
 ### Installing manually
 
 If you prefer to set ONCE up yourself, you can download the appropriate binary from the GitHub Releases page.
@@ -68,6 +76,15 @@ When you have an application selected on the dashboard, press `s` to view the se
 From there you can set up a location for automatic backups, update your hostname, switch to using your own fork's image, set up an email provider and more.
 
 You can also use the action menu, `a` to start and stop applications, or remove them completely.
+
+### Customizing the `once` appearance
+
+On first run, `once` shows an animated logo and background.
+If you find this distracting, or it causes problems in your environment, you can suppress it with `ONCE_REDUCED_MOTION=true`:
+
+```sh
+ONCE_REDUCED_MOTION=true once
+```
 
 ## Making a ONCE-compatible application
 

--- a/internal/ui/install.go
+++ b/internal/ui/install.go
@@ -3,6 +3,7 @@ package ui
 import (
 	"context"
 	"errors"
+	"os"
 	"strings"
 
 	"charm.land/bubbles/v2/key"
@@ -349,7 +350,7 @@ func (m Install) imageErrorState() installState {
 }
 
 func (m Install) showLogo() bool {
-	return len(m.namespace.Applications()) == 0
+	return len(m.namespace.Applications()) == 0 && os.Getenv("ONCE_REDUCED_MOTION") != "true"
 }
 
 func (m Install) middleHeight() int {

--- a/internal/ui/install_test.go
+++ b/internal/ui/install_test.go
@@ -220,6 +220,18 @@ func TestInstall_ShowsTitleAndHidesLogoWhenAppsExist(t *testing.T) {
 	assert.Contains(t, view, "ONCE · install")
 }
 
+func TestInstall_ShowLogo(t *testing.T) {
+	noApps := newTestNamespace()
+	withApps := newTestNamespace(docker.ApplicationSettings{Name: "myapp"})
+
+	assert.True(t, NewInstall(noApps, "").showLogo())
+	assert.False(t, NewInstall(withApps, "").showLogo())
+
+	t.Setenv("ONCE_REDUCED_MOTION", "true")
+	assert.False(t, NewInstall(noApps, "").showLogo())
+	assert.False(t, NewInstall(withApps, "").showLogo())
+}
+
 func TestInstall_PullFailureReturnsToImageForm(t *testing.T) {
 	ns := newTestNamespace()
 	m := NewInstall(ns, "")


### PR DESCRIPTION
Running with `ONCE_REDUCED_MOTION=true` will now supress the first-run animation, for cases where it's problematic or distracting.

Also documented the tool's ENV vars in the README.