### PR TITLE
Fix UI crash on teardown

### DIFF
--- a/internal/ui/dashboard.go
+++ b/internal/ui/dashboard.go
@@ -352,6 +352,10 @@ func (m *Dashboard) computeScales() DashboardScales {
 }
 
 func (m *Dashboard) scrollToSelection() {
+	if len(m.panels) == 0 {
+		return
+	}
+
 	panelTop := 0
 	for i := range m.selectedIndex {
 		panelTop += m.panels[i].Height(dashboardShowDetails)

--- a/internal/ui/dashboard_test.go
+++ b/internal/ui/dashboard_test.go
@@ -192,6 +192,23 @@ func TestDashboard_ToggleDetailsEmptyState(t *testing.T) {
 	assert.True(t, dashboardShowDetails) // unchanged — guarded by len(m.apps) > 0
 }
 
+func TestDashboard_SelectPanelAfterAppsRemoved(t *testing.T) {
+	d := testDashboard(3)
+	d.width = 80
+	d.height = 40
+	d.updateViewportSize()
+	d.rebuildViewportContent()
+
+	// Simulate all apps disappearing (e.g. `once teardown` in another shell).
+	d.apps = nil
+	d.buildPanels()
+
+	// Regression: #49 — scrollToSelection used to index into an empty m.panels.
+	assert.NotPanics(t, func() {
+		d.selectPanel(0)
+	})
+}
+
 func TestDashboard_EmptyStateShowsMessage(t *testing.T) {
 	d := testDashboard(0)
 	d, _ = updateDashboard(d, tea.WindowSizeMsg{Width: 80, Height: 24})


### PR DESCRIPTION
When the UI is open in one terminal, and teardown is triggered from another, the UI panics and crashes. This is due to the ScrollToSelection function which resolves the current Panel to nil and then tries to call Height on it.

Fixes: https://github.com/basecamp/once/issues/49