### PR TITLE
Add upgrade command

### DIFF
--- a/internal/command/root.go
+++ b/internal/command/root.go
@@ -47,6 +47,7 @@ func NewRootCommand() *RootCommand {
 	r.cmd.AddCommand(newStopCommand().cmd)
 	r.cmd.AddCommand(newTeardownCommand().cmd)
 	r.cmd.AddCommand(newUpdateCommand().cmd)
+	r.cmd.AddCommand(newUpgradeCommand().cmd)
 	r.cmd.AddCommand(newSelfUpdateCommand().cmd)
 	r.cmd.AddCommand(newVersionCommand().cmd)
 

--- a/internal/command/upgrade.go
+++ b/internal/command/upgrade.go
@@ -1,0 +1,53 @@
+package command
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/basecamp/once/internal/docker"
+)
+
+type upgradeCommand struct {
+	cmd *cobra.Command
+}
+
+func newUpgradeCommand() *upgradeCommand {
+	u := &upgradeCommand{}
+	u.cmd = &cobra.Command{
+		Use:   "upgrade <host>",
+		Short: "Check for and apply updates to a deployed application",
+		Args:  cobra.ExactArgs(1),
+		RunE:  WithNamespace(u.run),
+	}
+	return u
+}
+
+// Private
+
+func (u *upgradeCommand) run(ctx context.Context, ns *docker.Namespace, cmd *cobra.Command, args []string) error {
+	host := args[0]
+
+	app := ns.ApplicationByHost(host)
+	if app == nil {
+		return fmt.Errorf("no application found at host %q", host)
+	}
+
+	var changed bool
+	err := runWithProgress("Checking for updates to "+host, func(progress docker.DeployProgressCallback) error {
+		var err error
+		changed, err = app.Update(ctx, progress)
+		return err
+	})
+	if err != nil {
+		return err
+	}
+
+	if changed {
+		fmt.Printf("Updated %s\n", host)
+	} else {
+		fmt.Printf("%s is already running the latest version\n", host)
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary

- Adds `once upgrade <host>` CLI command that checks for a newer Docker image and redeploys the application if one is found
- Mirrors the "Check for updates" action already available in the TUI settings form
- Prints `Updated <host>` on success or `<host> is already running the latest version` when no update is available

## Test plan

- [ ] `once upgrade <host>` pulls the latest image and redeploys when a newer version exists
- [ ] `once upgrade <host>` reports already-up-to-date when no newer image is available
- [ ] `once upgrade <unknown-host>` returns an appropriate error

🤖 Generated with [Claude Code](https://claude.com/claude-code)