### PR TITLE
🐛 (install_app_list): pin fizzy image to :main tag

### DIFF
--- a/internal/ui/install_app_list.go
+++ b/internal/ui/install_app_list.go
@@ -15,7 +15,7 @@ type KnownApp struct {
 
 var knownApps = []KnownApp{
 	{Name: "Campfire", Alias: "campfire", ImageRef: "ghcr.io/basecamp/once-campfire"},
-	{Name: "Fizzy", Alias: "fizzy", ImageRef: "ghcr.io/basecamp/fizzy"},
+	{Name: "Fizzy", Alias: "fizzy", ImageRef: "ghcr.io/basecamp/fizzy:main"},
 	{Name: "Writebook", Alias: "writebook", ImageRef: "ghcr.io/basecamp/writebook"},
 }
 

--- a/internal/ui/install_app_list_test.go
+++ b/internal/ui/install_app_list_test.go
@@ -54,7 +54,7 @@ func TestInstallAppList_NavigateAndSelect(t *testing.T) {
 	msg := cmd()
 	selected, ok := msg.(InstallAppSelectedMsg)
 	require.True(t, ok, "expected InstallAppSelectedMsg, got %T", msg)
-	assert.Equal(t, "ghcr.io/basecamp/fizzy", selected.ImageRef)
+	assert.Equal(t, "ghcr.io/basecamp/fizzy:main", selected.ImageRef)
 }
 
 func TestInstallAppList_View(t *testing.T) {
@@ -75,7 +75,7 @@ func TestExpandAlias(t *testing.T) {
 
 	ref, ok = expandAlias("fizzy")
 	assert.True(t, ok)
-	assert.Equal(t, "ghcr.io/basecamp/fizzy", ref)
+	assert.Equal(t, "ghcr.io/basecamp/fizzy:main", ref)
 
 	ref, ok = expandAlias("writebook")
 	assert.True(t, ok)


### PR DESCRIPTION
## Summary
Pins the built-in Fizzy app entry to `ghcr.io/basecamp/fizzy:main` instead of the
tagless ref (which resolved to a frozen `:latest`). Fizzy's CI only advances `:main`;
`:latest` hasn't moved in months, so new installs were silently tracking a stale image
while the auto-updater correctly reported "up to date."

## Changes
- Fizzy `ImageRef` → `ghcr.io/basecamp/fizzy:main` (`internal/ui/install_app_list.go`)
- Updated the two corresponding test assertions (`TestInstallAppList_NavigateAndSelect`,
  `TestExpandAlias`)

## Context
- Fizzy's publish workflow only moves `:latest` on `v*` tags, and Fizzy has never cut one
  (releases use the `fizzy@<sha>` scheme). The actively-published, multi-arch tag is `:main`,
  which Fizzy's own deployment docs recommend.
- A pinned digest is deliberately avoided — it would defeat ONCE's tag-based auto-update
  and recreate the silent-staleness condition.
- `:main` and `:latest` are genuinely different images (verified via `docker manifest inspect`):
  amd64 `:main` `62b174a6…` vs `:latest` `f1b641a1…`; arm64 `4c46553c…` vs `6eb940e0…`.
- `:main` is multi-arch (amd64 + arm64), so no platform handling is needed; the string flows
  verbatim to `ImagePull`/`ImageInspect` (no tag normalization touches it).

## Caveats
- **New installs only.** `Settings.Image` is persisted per-app at install time, so already-deployed
  Fizzy instances keep the stale tag. Recovery: `once update <host> --image ghcr.io/basecamp/fizzy:main`.
  A settings migration is a possible follow-up, out of scope here.
- Campfire and Writebook use the same tagless pattern; their `:latest` status is unverified, so
  they're left untouched — worth a separate audit.