### PR TITLE
Add a `once exec ...` command

### DIFF
--- a/cmd/once/main.go
+++ b/cmd/once/main.go
@@ -11,6 +11,9 @@ func main() {
 	logging.SetupStderr()
 
 	if err := command.NewRootCommand().Execute(); err != nil {
+		if code, ok := command.ExitCode(err); ok {
+			os.Exit(code)
+		}
 		os.Exit(1)
 	}
 }

--- a/integration/docker_test.go
+++ b/integration/docker_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/basecamp/once/internal/command"
 	"github.com/basecamp/once/internal/docker"
 )
 
@@ -243,6 +244,56 @@ func TestStartStop(t *testing.T) {
 
 	require.NoError(t, app.Start(ctx))
 	assertContainerRunning(t, ctx, containerName, true)
+}
+
+func TestExec(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	ns, err := docker.NewNamespace("once-exec-test")
+	require.NoError(t, err)
+	defer ns.Teardown(ctx, true)
+
+	require.NoError(t, ns.EnsureNetwork(ctx))
+	require.NoError(t, ns.Proxy().Boot(ctx, getProxyPorts(t)))
+
+	app := deployApp(t, ctx, ns, docker.ApplicationSettings{
+		Name:  "exec",
+		Image: "ghcr.io/basecamp/once-campfire:main",
+		Host:  "exec.localhost",
+	})
+
+	require.NoError(t, app.Exec(ctx, []string{"sh", "-c", "exit 0"}))
+
+	err = app.Exec(ctx, []string{"sh", "-c", "exit 7"})
+	require.Error(t, err)
+	code, ok := command.ExitCode(err)
+	assert.True(t, ok)
+	assert.Equal(t, 7, code)
+}
+
+func TestExecFailsWhenNotRunning(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	ns, err := docker.NewNamespace("once-exec-stopped-test")
+	require.NoError(t, err)
+	defer ns.Teardown(ctx, true)
+
+	require.NoError(t, ns.EnsureNetwork(ctx))
+	require.NoError(t, ns.Proxy().Boot(ctx, getProxyPorts(t)))
+
+	app := deployApp(t, ctx, ns, docker.ApplicationSettings{
+		Name:  "exec-stopped",
+		Image: "ghcr.io/basecamp/once-campfire:main",
+		Host:  "exec-stopped.localhost",
+	})
+
+	require.NoError(t, app.Stop(ctx))
+	require.NoError(t, ns.Refresh(ctx))
+
+	err = ns.Application("exec-stopped").Exec(ctx, []string{"sh", "-c", "exit 0"})
+	assert.ErrorIs(t, err, docker.ErrApplicationNotRunning)
 }
 
 func TestLongAppName(t *testing.T) {

--- a/internal/command/exec.go
+++ b/internal/command/exec.go
@@ -1,0 +1,57 @@
+package command
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/basecamp/once/internal/docker"
+)
+
+type execCommand struct {
+	cmd *cobra.Command
+}
+
+func newExecCommand() *execCommand {
+	e := &execCommand{}
+	e.cmd = &cobra.Command{
+		Use:   "exec <host> <command> [args...]",
+		Short: "Execute a command in an application container",
+		Args:  cobra.MinimumNArgs(2),
+		RunE:  WithNamespace(e.run),
+	}
+	e.cmd.Flags().SetInterspersed(false)
+	return e
+}
+
+// Private
+
+func (e *execCommand) run(ctx context.Context, ns *docker.Namespace, cmd *cobra.Command, args []string) error {
+	host, commandArgs, err := splitExecArgs(args)
+	if err != nil {
+		return err
+	}
+
+	err = withApplication(ns, host, "executing command in", func(app *docker.Application) error {
+		return app.Exec(ctx, commandArgs)
+	})
+	if IsExitError(err) {
+		cmd.SilenceErrors = true
+	}
+	return err
+}
+
+// Helpers
+
+func splitExecArgs(args []string) (string, []string, error) {
+	commandArgs := args[1:]
+	if commandArgs[0] == "--" {
+		commandArgs = commandArgs[1:]
+	}
+	if len(commandArgs) == 0 {
+		return "", nil, fmt.Errorf("command is required")
+	}
+
+	return args[0], commandArgs, nil
+}

--- a/internal/command/exec_test.go
+++ b/internal/command/exec_test.go
@@ -1,0 +1,39 @@
+package command
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSplitExecArgs(t *testing.T) {
+	host, commandArgs, err := splitExecArgs([]string{"myapp.example.com", "rails", "console"})
+
+	require.NoError(t, err)
+	assert.Equal(t, "myapp.example.com", host)
+	assert.Equal(t, []string{"rails", "console"}, commandArgs)
+}
+
+func TestSplitExecArgsAllowsFlagArgs(t *testing.T) {
+	host, commandArgs, err := splitExecArgs([]string{"myapp.example.com", "ls", "-la"})
+
+	require.NoError(t, err)
+	assert.Equal(t, "myapp.example.com", host)
+	assert.Equal(t, []string{"ls", "-la"}, commandArgs)
+}
+
+func TestSplitExecArgsAllowsSeparator(t *testing.T) {
+	host, commandArgs, err := splitExecArgs([]string{"myapp.example.com", "--", "sh", "-lc", "echo hi"})
+
+	require.NoError(t, err)
+	assert.Equal(t, "myapp.example.com", host)
+	assert.Equal(t, []string{"sh", "-lc", "echo hi"}, commandArgs)
+}
+
+func TestSplitExecArgsRequiresCommand(t *testing.T) {
+	_, _, err := splitExecArgs([]string{"myapp.example.com", "--"})
+
+	require.Error(t, err)
+	assert.Equal(t, "command is required", err.Error())
+}

--- a/internal/command/root.go
+++ b/internal/command/root.go
@@ -2,6 +2,7 @@ package command
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/spf13/cobra"
@@ -40,6 +41,7 @@ func NewRootCommand() *RootCommand {
 	r.cmd.AddCommand(newBackgroundCommand().cmd)
 	r.cmd.AddCommand(newBackupCommand().cmd)
 	r.cmd.AddCommand(newDeployCommand().cmd)
+	r.cmd.AddCommand(newExecCommand().cmd)
 	r.cmd.AddCommand(newListCommand().cmd)
 	r.cmd.AddCommand(newRemoveCommand().cmd)
 	r.cmd.AddCommand(newRestoreCommand().cmd)
@@ -90,4 +92,21 @@ func WithNamespace(fn NamespaceRunE) func(*cobra.Command, []string) error {
 func namespaceFlag(cmd *cobra.Command) string {
 	namespace, _ := cmd.Root().PersistentFlags().GetString("namespace")
 	return namespace
+}
+
+type exitCoder interface {
+	error
+	ExitCode() int
+}
+
+func ExitCode(err error) (int, bool) {
+	if e, ok := errors.AsType[exitCoder](err); ok {
+		return e.ExitCode(), true
+	}
+	return 0, false
+}
+
+func IsExitError(err error) bool {
+	_, ok := ExitCode(err)
+	return ok
 }

--- a/internal/docker/application.go
+++ b/internal/docker/application.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/containerd/errdefs"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/api/types/mount"
@@ -23,6 +24,7 @@ var (
 	ErrHostRequired          = errors.New("host is required")
 	ErrInvalidBackup         = errors.New("invalid backup archive")
 	ErrImageRequired         = errors.New("image is required")
+	ErrApplicationNotRunning = errors.New("the application is not running")
 	ErrBackupPathRelative    = errors.New("backup path must be absolute")
 	ErrAutoBackupWithoutPath = errors.New("auto-backup requires a backup path")
 	ErrSetupFailed           = errors.New("setup failed")
@@ -155,6 +157,22 @@ func (a *Application) Start(ctx context.Context) error {
 	}
 
 	return a.namespace.client.ContainerStart(ctx, name, container.StartOptions{})
+}
+
+func (a *Application) Exec(ctx context.Context, cmd []string) error {
+	name, err := a.ContainerName(ctx)
+	if err != nil {
+		return err
+	}
+
+	if err := execAttachedInContainer(ctx, a.namespace.client, name, cmd); err != nil {
+		if errdefs.IsConflict(err) {
+			return ErrApplicationNotRunning
+		}
+		return err
+	}
+
+	return nil
 }
 
 func (a *Application) Update(ctx context.Context, progress DeployProgressCallback) (bool, error) {

--- a/internal/docker/container.go
+++ b/internal/docker/container.go
@@ -4,7 +4,14 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io"
+	"os"
+	"os/signal"
+	"sync"
+	"syscall"
 
+	"github.com/charmbracelet/x/term"
+	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/client"
 	"github.com/docker/docker/pkg/stdcopy"
@@ -28,19 +35,16 @@ type ExecResult struct {
 	ExitCode int
 }
 
+// Helpers
+
 func execInContainer(ctx context.Context, c *client.Client, containerName string, cmd []string) (ExecResult, error) {
-	execResp, err := c.ContainerExecCreate(ctx, containerName, container.ExecOptions{
+	execID, resp, err := startExec(ctx, c, containerName, container.ExecOptions{
 		Cmd:          cmd,
 		AttachStdout: true,
 		AttachStderr: true,
 	})
 	if err != nil {
-		return ExecResult{}, fmt.Errorf("creating exec: %w", err)
-	}
-
-	resp, err := c.ContainerExecAttach(ctx, execResp.ID, container.ExecStartOptions{})
-	if err != nil {
-		return ExecResult{}, fmt.Errorf("attaching exec: %w", err)
+		return ExecResult{}, err
 	}
 	defer resp.Close()
 
@@ -49,14 +53,189 @@ func execInContainer(ctx context.Context, c *client.Client, containerName string
 		return ExecResult{}, fmt.Errorf("reading exec output: %w", err)
 	}
 
-	inspect, err := c.ContainerExecInspect(ctx, execResp.ID)
+	exitCode, err := inspectExecExitCode(ctx, c, execID)
 	if err != nil {
-		return ExecResult{}, fmt.Errorf("inspecting exec: %w", err)
+		return ExecResult{}, err
 	}
 
 	return ExecResult{
 		Stdout:   stdout.String(),
 		Stderr:   stderr.String(),
-		ExitCode: inspect.ExitCode,
+		ExitCode: exitCode,
 	}, nil
+}
+
+func execAttachedInContainer(ctx context.Context, c *client.Client, containerName string, cmd []string) error {
+	stdinFD := os.Stdin.Fd()
+	stdoutFD := os.Stdout.Fd()
+	tty := term.IsTerminal(stdinFD) && term.IsTerminal(stdoutFD)
+	consoleSize := execConsoleSize(stdoutFD, tty)
+
+	restoreTerminal := func() {}
+	if tty {
+		state, err := term.MakeRaw(stdinFD)
+		if err != nil {
+			return fmt.Errorf("setting terminal raw mode: %w", err)
+		}
+
+		var once sync.Once
+		restoreTerminal = func() {
+			once.Do(func() {
+				_ = term.Restore(stdinFD, state)
+			})
+		}
+		defer restoreTerminal()
+	}
+
+	execID, resp, err := startExec(ctx, c, containerName, container.ExecOptions{
+		Cmd:          cmd,
+		Tty:          tty,
+		ConsoleSize:  consoleSize,
+		AttachStdin:  true,
+		AttachStdout: true,
+		AttachStderr: true,
+	})
+	if err != nil {
+		return err
+	}
+	defer resp.Close()
+
+	resizeCtx, cancelResize := context.WithCancel(ctx)
+	defer cancelResize()
+	if tty {
+		monitorExecTTYSize(resizeCtx, c, execID, stdoutFD)
+	}
+
+	go func() {
+		_, _ = io.Copy(resp.Conn, os.Stdin)
+		_ = resp.CloseWrite()
+	}()
+
+	if err := copyExecOutput(resp.Reader, tty); err != nil {
+		restoreTerminal()
+		return err
+	}
+	restoreTerminal()
+
+	exitCode, err := inspectExecExitCode(ctx, c, execID)
+	if err != nil {
+		return err
+	}
+	if exitCode != 0 {
+		return execExitError{exitCode: exitCode}
+	}
+
+	return nil
+}
+
+func startExec(ctx context.Context, c *client.Client, containerName string, opts container.ExecOptions) (string, types.HijackedResponse, error) {
+	execResp, err := c.ContainerExecCreate(ctx, containerName, opts)
+	if err != nil {
+		return "", types.HijackedResponse{}, fmt.Errorf("creating exec: %w", err)
+	}
+	if execResp.ID == "" {
+		return "", types.HijackedResponse{}, fmt.Errorf("creating exec: empty exec ID")
+	}
+
+	resp, err := c.ContainerExecAttach(ctx, execResp.ID, container.ExecStartOptions{
+		Tty:         opts.Tty,
+		ConsoleSize: opts.ConsoleSize,
+	})
+	if err != nil {
+		return "", types.HijackedResponse{}, fmt.Errorf("attaching exec: %w", err)
+	}
+
+	return execResp.ID, resp, nil
+}
+
+func inspectExecExitCode(ctx context.Context, c *client.Client, execID string) (int, error) {
+	inspect, err := c.ContainerExecInspect(ctx, execID)
+	if err != nil {
+		return 0, fmt.Errorf("inspecting exec: %w", err)
+	}
+	return inspect.ExitCode, nil
+}
+
+func copyExecOutput(r io.Reader, tty bool) error {
+	var err error
+	if tty {
+		_, err = io.Copy(os.Stdout, r)
+	} else {
+		_, err = stdcopy.StdCopy(os.Stdout, os.Stderr, r)
+	}
+	if err != nil {
+		return fmt.Errorf("reading exec output: %w", err)
+	}
+	return nil
+}
+
+func execConsoleSize(fd uintptr, tty bool) *[2]uint {
+	if !tty {
+		return nil
+	}
+
+	width, height, ok := terminalSize(fd)
+	if !ok {
+		return nil
+	}
+
+	return &[2]uint{height, width}
+}
+
+func monitorExecTTYSize(ctx context.Context, c *client.Client, execID string, fd uintptr) {
+	resize := func() {
+		if options, ok := execResizeOptions(fd); ok {
+			_ = c.ContainerExecResize(ctx, execID, options)
+		}
+	}
+
+	resize()
+
+	sigwinch := make(chan os.Signal, 1)
+	signal.Notify(sigwinch, syscall.SIGWINCH)
+
+	go func() {
+		defer signal.Stop(sigwinch)
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-sigwinch:
+				resize()
+			}
+		}
+	}()
+}
+
+func execResizeOptions(fd uintptr) (container.ResizeOptions, bool) {
+	width, height, ok := terminalSize(fd)
+	if !ok {
+		return container.ResizeOptions{}, false
+	}
+
+	return container.ResizeOptions{
+		Height: height,
+		Width:  width,
+	}, true
+}
+
+func terminalSize(fd uintptr) (uint, uint, bool) {
+	width, height, err := term.GetSize(fd)
+	if err != nil || width <= 0 || height <= 0 {
+		return 0, 0, false
+	}
+
+	return uint(width), uint(height), true
+}
+
+type execExitError struct {
+	exitCode int
+}
+
+func (e execExitError) Error() string {
+	return fmt.Sprintf("command exited with status %d", e.exitCode)
+}
+
+func (e execExitError) ExitCode() int {
+	return e.exitCode
 }


### PR DESCRIPTION
Adds a new CLI command, `exec` which executes a command in an application's running container. Much like `docker exec`, `docker compose exec`, etc.

- Will attach a TTY as necessary, so interactive commands work without additional flags
- Passes back the exit code from the command

Closes #59