### PR TITLE
Allow resetting secrets

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,9 +43,10 @@ been set up using Once itself. For example, the list of applications that are
 deployed, the hostname and TLS settings for each, any custom port settings for
 the proxy, and so on. Once stores this information as JSON strings in an `once`
 label on the containers and volumes, so that everything is stored within the
-Docker state. Application settings go with the app container; proxy settings go
-with the proxy container; volume settings (like encryption keys) go with the
-volume.
+Docker state. Application settings (including the app's secret keys) go with
+the app container; proxy settings go with the proxy container. Some older
+installs may have the app's keys on the volume label, as that's how they used
+to be stored.
 
 ## Build Commands
 

--- a/integration/docker_test.go
+++ b/integration/docker_test.go
@@ -87,6 +87,56 @@ func TestRestoreState(t *testing.T) {
 	assert.Equal(t, app.Settings.Image, restoredApp.Settings.Image)
 }
 
+func TestRestoreAdoptsLegacyVolumeKeys(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	ns, err := docker.NewNamespace("once-legacy-keys-test")
+	require.NoError(t, err)
+	defer ns.Teardown(ctx, true)
+
+	legacyKeys := docker.Keys{
+		SecretKeyBase:   "legacy-secret",
+		VAPIDPublicKey:  "legacy-pub",
+		VAPIDPrivateKey: "legacy-priv",
+	}
+	_, err = docker.CreateVolume(ctx, ns, "legacyapp", docker.ApplicationLegacyVolumeSettings{Keys: legacyKeys})
+	require.NoError(t, err)
+
+	// A legacy install's app container has settings without keys on its label
+	settings := docker.ApplicationSettings{
+		Name:  "legacyapp",
+		Image: "ghcr.io/basecamp/once-campfire:main",
+		Host:  "legacyapp.localhost",
+	}
+
+	c, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
+	require.NoError(t, err)
+	defer c.Close()
+
+	reader, err := c.ImagePull(ctx, settings.Image, image.PullOptions{})
+	require.NoError(t, err)
+	io.Copy(io.Discard, reader)
+	reader.Close()
+
+	_, err = c.ContainerCreate(ctx,
+		&container.Config{
+			Image:  settings.Image,
+			Labels: map[string]string{"once": settings.Marshal()},
+		},
+		nil, nil, nil,
+		"once-legacy-keys-test-app-legacyapp-abc123",
+	)
+	require.NoError(t, err)
+
+	restored, err := docker.RestoreNamespace(ctx, "once-legacy-keys-test")
+	require.NoError(t, err)
+
+	app := restored.Application("legacyapp")
+	require.NotNil(t, app)
+	assert.Equal(t, legacyKeys, app.Settings.Keys)
+}
+
 func TestApplicationVolume(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()
@@ -94,13 +144,13 @@ func TestApplicationVolume(t *testing.T) {
 	ns, err := docker.NewNamespace("once-volume-label-test")
 	require.NoError(t, err)
 
-	vol1, err := docker.CreateVolume(ctx, ns, "testapp", docker.ApplicationVolumeSettings{SecretKeyBase: "test-secret"})
+	vol1, err := docker.CreateVolume(ctx, ns, "testapp", docker.ApplicationLegacyVolumeSettings{Keys: docker.Keys{SecretKeyBase: "test-secret"}})
 	require.NoError(t, err)
-	assert.Equal(t, "test-secret", vol1.SecretKeyBase())
+	assert.Equal(t, "test-secret", vol1.Settings.SecretKeyBase)
 
 	vol2, err := docker.FindVolume(ctx, ns, "testapp")
 	require.NoError(t, err)
-	assert.Equal(t, vol1.SecretKeyBase(), vol2.SecretKeyBase())
+	assert.Equal(t, vol1.Settings.SecretKeyBase, vol2.Settings.SecretKeyBase)
 
 	require.NoError(t, vol1.Destroy(ctx))
 }
@@ -122,9 +172,8 @@ func TestGaplessDeployment(t *testing.T) {
 		Host:  "gapless.localhost",
 	})
 
-	vol, err := app.Volume(ctx)
-	require.NoError(t, err)
-	firstSecretKeyBase := vol.SecretKeyBase()
+	firstSecretKeyBase := app.Settings.Keys.SecretKeyBase
+	require.NotEmpty(t, firstSecretKeyBase)
 
 	firstName, err := app.ContainerName(ctx)
 	require.NoError(t, err)
@@ -137,16 +186,13 @@ func TestGaplessDeployment(t *testing.T) {
 	countAfter := countContainers(t, ctx, containerPrefix)
 	assert.Equal(t, countBefore, countAfter, "container count should not change")
 
-	vol2, err := app.Volume(ctx)
-	require.NoError(t, err)
-	assert.Equal(t, firstSecretKeyBase, vol2.SecretKeyBase(), "SecretKeyBase should persist across deploys")
-
 	secondName, err := app.ContainerName(ctx)
 	require.NoError(t, err)
 	assert.NotEqual(t, firstName, secondName, "container name should change between deploys")
 
 	require.NoError(t, ns.Refresh(ctx))
 	assert.Len(t, ns.Applications(), 1, "should have exactly one application after redeploy and refresh")
+	assert.Equal(t, firstSecretKeyBase, ns.Application("gapless").Settings.Keys.SecretKeyBase, "SecretKeyBase should persist across deploys")
 }
 
 func TestUpdateDetectsLocalImageChange(t *testing.T) {
@@ -389,11 +435,9 @@ func TestBackup(t *testing.T) {
 	require.NoError(t, json.Unmarshal(entries["once.application.json"], &appSettings))
 	assert.Equal(t, "backupapp", appSettings.Name)
 	assert.Equal(t, imageName, appSettings.Image)
+	assert.NotEmpty(t, appSettings.Keys.SecretKeyBase)
 
 	assert.Contains(t, entries, "once.volume.json")
-	var volSettings docker.ApplicationVolumeSettings
-	require.NoError(t, json.Unmarshal(entries["once.volume.json"], &volSettings))
-	assert.NotEmpty(t, volSettings.SecretKeyBase)
 
 	assert.Contains(t, entries, "data/testfile.txt")
 	assert.Equal(t, "test content\n", string(entries["data/testfile.txt"]))
@@ -425,9 +469,8 @@ func TestRestore(t *testing.T) {
 		"sh", "-c", "echo 'restore test data' > /rails/storage/restore-test.txt",
 	})
 
-	vol, err := app.Volume(ctx)
-	require.NoError(t, err)
-	originalSecretKeyBase := vol.SecretKeyBase()
+	originalSecretKeyBase := app.Settings.Keys.SecretKeyBase
+	require.NotEmpty(t, originalSecretKeyBase)
 
 	backupDir := t.TempDir()
 	require.NoError(t, app.BackupToFile(ctx, backupDir, "backup.tar.gz"))
@@ -457,10 +500,8 @@ func TestRestore(t *testing.T) {
 	assert.NotNil(t, ns2.Application(restoredApp.Settings.Name), "app should be in namespace immediately after Restore")
 	assert.True(t, ns2.HostInUse("restore.localhost"), "hostname should be in use after Restore")
 
-	// Verify volume settings (SecretKeyBase) were preserved
-	restoredVol, err := restoredApp.Volume(ctx)
-	require.NoError(t, err)
-	assert.Equal(t, originalSecretKeyBase, restoredVol.SecretKeyBase())
+	// Verify the keys (SecretKeyBase) were preserved
+	assert.Equal(t, originalSecretKeyBase, restoredApp.Settings.Keys.SecretKeyBase)
 
 	// Verify data was restored
 	restoredContainerName, err := restoredApp.ContainerName(ctx)
@@ -480,9 +521,7 @@ func TestRestore(t *testing.T) {
 	assert.Equal(t, imageName, restoredAppFromState.Settings.Image)
 	assert.Equal(t, "restore.localhost", restoredAppFromState.Settings.Host)
 
-	volFromState, err := restoredAppFromState.Volume(ctx)
-	require.NoError(t, err)
-	assert.Equal(t, originalSecretKeyBase, volFromState.SecretKeyBase(), "volume SecretKeyBase should be preserved")
+	assert.Equal(t, originalSecretKeyBase, restoredAppFromState.Settings.Keys.SecretKeyBase, "SecretKeyBase should be preserved")
 }
 
 func TestRestoreHostnameConflictFails(t *testing.T) {
@@ -630,6 +669,7 @@ func TestRestoreWithPostRestoreHook(t *testing.T) {
 	restoredApp, err := ns.Restore(ctx, bytes.NewReader(backup))
 	require.NoError(t, err)
 	assert.NotEmpty(t, restoredApp.Settings.Name)
+	assert.Equal(t, "test-secret-key", restoredApp.Settings.Keys.SecretKeyBase, "legacy key from backup volume settings should migrate to app settings")
 
 	containerName, err := restoredApp.ContainerName(ctx)
 	require.NoError(t, err)
@@ -825,9 +865,8 @@ func TestUpdatePreservesSettings(t *testing.T) {
 		Resources: docker.ContainerResources{CPUs: 2, MemoryMB: 1024},
 	})
 
-	vol, err := app.Volume(ctx)
-	require.NoError(t, err)
-	originalSecretKeyBase := vol.SecretKeyBase()
+	originalSecretKeyBase := app.Settings.Keys.SecretKeyBase
+	require.NotEmpty(t, originalSecretKeyBase)
 
 	// Update only the env vars, leaving everything else as-is
 	newSettings := app.Settings
@@ -855,10 +894,8 @@ func TestUpdatePreservesSettings(t *testing.T) {
 	assert.Contains(t, envVars, "NEW_VAR=new_value")
 	assertEnvAbsent(t, envVars, "MY_VAR")
 
-	// Volume preserved
-	vol2, err := updatedApp.Volume(ctx)
-	require.NoError(t, err)
-	assert.Equal(t, originalSecretKeyBase, vol2.SecretKeyBase())
+	// Keys preserved
+	assert.Equal(t, originalSecretKeyBase, updatedApp.Settings.Keys.SecretKeyBase)
 }
 
 func TestUpdateChangeHost(t *testing.T) {
@@ -1216,7 +1253,7 @@ func buildTestBackup(t *testing.T, imageName string) []byte {
 		Image: imageName,
 		Host:  "hookapp.localhost",
 	}
-	volSettings := docker.ApplicationVolumeSettings{SecretKeyBase: "test-secret-key"}
+	volSettings := docker.ApplicationLegacyVolumeSettings{Keys: docker.Keys{SecretKeyBase: "test-secret-key"}}
 
 	var buf bytes.Buffer
 	gw := gzip.NewWriter(&buf)

--- a/integration/docker_test.go
+++ b/integration/docker_test.go
@@ -898,6 +898,44 @@ func TestUpdatePreservesSettings(t *testing.T) {
 	assert.Equal(t, originalSecretKeyBase, updatedApp.Settings.Keys.SecretKeyBase)
 }
 
+func TestUpdateSettings(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	ns, err := docker.NewNamespace("once-update-settings-test")
+	require.NoError(t, err)
+	defer ns.Teardown(ctx, true)
+
+	require.NoError(t, ns.EnsureNetwork(ctx))
+	require.NoError(t, ns.Proxy().Boot(ctx, getProxyPorts(t)))
+
+	app := deployApp(t, ctx, ns, docker.ApplicationSettings{
+		Name:  "updatesettingsapp",
+		Image: "ghcr.io/basecamp/once-campfire:main",
+		Host:  "updatesettings.localhost",
+	})
+
+	oldContainerName, err := app.ContainerName(ctx)
+	require.NoError(t, err)
+
+	newSettings := app.Settings
+	newSettings.EnvVars = map[string]string{"UPDATED_VAR": "updated_value"}
+	require.NoError(t, app.UpdateSettings(ctx, newSettings, nil))
+	require.NoError(t, ns.Refresh(ctx))
+
+	updatedApp := ns.ApplicationByHost("updatesettings.localhost")
+	require.NotNil(t, updatedApp)
+	assert.True(t, updatedApp.Running)
+	assert.Equal(t, "updated_value", updatedApp.Settings.EnvVars["UPDATED_VAR"])
+
+	containerName, err := updatedApp.ContainerName(ctx)
+	require.NoError(t, err)
+	assert.NotEqual(t, oldContainerName, containerName)
+
+	envVars := inspectContainerEnv(t, ctx, containerName)
+	assert.Contains(t, envVars, "UPDATED_VAR=updated_value")
+}
+
 func TestUpdateChangeHost(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()

--- a/internal/command/keys.go
+++ b/internal/command/keys.go
@@ -1,0 +1,19 @@
+package command
+
+import "github.com/spf13/cobra"
+
+type keysCommand struct {
+	cmd *cobra.Command
+}
+
+func newKeysCommand() *keysCommand {
+	k := &keysCommand{}
+	k.cmd = &cobra.Command{
+		Use:   "keys",
+		Short: "Manage application secret keys",
+	}
+
+	k.cmd.AddCommand(newKeysResetCommand().cmd)
+
+	return k
+}

--- a/internal/command/keys.go
+++ b/internal/command/keys.go
@@ -14,6 +14,7 @@ func newKeysCommand() *keysCommand {
 	}
 
 	k.cmd.AddCommand(newKeysResetCommand().cmd)
+	k.cmd.AddCommand(newKeysSetCommand().cmd)
 
 	return k
 }

--- a/internal/command/keys.go
+++ b/internal/command/keys.go
@@ -1,6 +1,13 @@
 package command
 
-import "github.com/spf13/cobra"
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/basecamp/once/internal/docker"
+)
 
 type keysCommand struct {
 	cmd *cobra.Command
@@ -17,4 +24,33 @@ func newKeysCommand() *keysCommand {
 	k.cmd.AddCommand(newKeysSetCommand().cmd)
 
 	return k
+}
+
+// Helpers
+
+func changeKeys(ctx context.Context, ns *docker.Namespace, host string, label string, change func(*docker.Keys) error) error {
+	app := ns.ApplicationByHost(host)
+	if app == nil {
+		return fmt.Errorf("no application found at host %q", host)
+	}
+
+	if !app.Running {
+		return docker.ErrApplicationNotRunning
+	}
+
+	if err := ns.Setup(ctx); err != nil {
+		return fmt.Errorf("%w: %w", docker.ErrSetupFailed, err)
+	}
+
+	settings := app.Settings
+	if err := change(&settings.Keys); err != nil {
+		return err
+	}
+
+	return runWithProgress(label+" "+host, func(progress docker.DeployProgressCallback) error {
+		if err := app.UpdateSettings(ctx, settings, progress); err != nil {
+			return fmt.Errorf("%w: %w", docker.ErrDeployFailed, err)
+		}
+		return nil
+	})
 }

--- a/internal/command/keys.go
+++ b/internal/command/keys.go
@@ -29,9 +29,9 @@ func newKeysCommand() *keysCommand {
 // Helpers
 
 func changeKeys(ctx context.Context, ns *docker.Namespace, host string, label string, change func(*docker.Keys) error) error {
-	app := ns.ApplicationByHost(host)
-	if app == nil {
-		return fmt.Errorf("no application found at host %q", host)
+	app, err := findApplication(ns, host)
+	if err != nil {
+		return err
 	}
 
 	if !app.Running {

--- a/internal/command/keys_reset.go
+++ b/internal/command/keys_reset.go
@@ -34,33 +34,9 @@ func newKeysResetCommand() *keysResetCommand {
 // Private
 
 func (k *keysResetCommand) run(ctx context.Context, ns *docker.Namespace, cmd *cobra.Command, args []string) error {
-	host := args[0]
-
-	app := ns.ApplicationByHost(host)
-	if app == nil {
-		return fmt.Errorf("no application found at host %q", host)
-	}
-
-	if !app.Running {
-		return docker.ErrApplicationNotRunning
-	}
-
-	if err := ns.Setup(ctx); err != nil {
-		return fmt.Errorf("%w: %w", docker.ErrSetupFailed, err)
-	}
-
-	settings := app.Settings
-	if err := settings.Keys.Regenerate(k.secretKeyBase, k.vapid); err != nil {
-		return fmt.Errorf("regenerating keys: %w", err)
-	}
-
-	oldSettings := app.Settings
-	app.Settings = settings
-
-	return runWithProgress("Resetting keys for "+host, func(progress docker.DeployProgressCallback) error {
-		if err := app.Deploy(ctx, progress); err != nil {
-			app.Settings = oldSettings
-			return fmt.Errorf("%w: %w", docker.ErrDeployFailed, err)
+	return changeKeys(ctx, ns, args[0], "Resetting keys for", func(keys *docker.Keys) error {
+		if err := keys.Regenerate(k.secretKeyBase, k.vapid); err != nil {
+			return fmt.Errorf("regenerating keys: %w", err)
 		}
 		return nil
 	})

--- a/internal/command/keys_reset.go
+++ b/internal/command/keys_reset.go
@@ -1,0 +1,67 @@
+package command
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/basecamp/once/internal/docker"
+)
+
+type keysResetCommand struct {
+	cmd           *cobra.Command
+	secretKeyBase bool
+	vapid         bool
+}
+
+func newKeysResetCommand() *keysResetCommand {
+	k := &keysResetCommand{}
+	k.cmd = &cobra.Command{
+		Use:   "reset <host>",
+		Short: "Regenerate secret keys and redeploy the application",
+		Args:  cobra.ExactArgs(1),
+		RunE:  WithNamespace(k.run),
+	}
+
+	k.cmd.Flags().BoolVar(&k.secretKeyBase, "secret-key-base", false, "regenerate the secret key base")
+	k.cmd.Flags().BoolVar(&k.vapid, "vapid", false, "regenerate the VAPID key pair")
+	k.cmd.MarkFlagsOneRequired("secret-key-base", "vapid")
+
+	return k
+}
+
+// Private
+
+func (k *keysResetCommand) run(ctx context.Context, ns *docker.Namespace, cmd *cobra.Command, args []string) error {
+	host := args[0]
+
+	app := ns.ApplicationByHost(host)
+	if app == nil {
+		return fmt.Errorf("no application found at host %q", host)
+	}
+
+	if !app.Running {
+		return docker.ErrApplicationNotRunning
+	}
+
+	if err := ns.Setup(ctx); err != nil {
+		return fmt.Errorf("%w: %w", docker.ErrSetupFailed, err)
+	}
+
+	settings := app.Settings
+	if err := settings.Keys.Regenerate(k.secretKeyBase, k.vapid); err != nil {
+		return fmt.Errorf("regenerating keys: %w", err)
+	}
+
+	oldSettings := app.Settings
+	app.Settings = settings
+
+	return runWithProgress("Resetting keys for "+host, func(progress docker.DeployProgressCallback) error {
+		if err := app.Deploy(ctx, progress); err != nil {
+			app.Settings = oldSettings
+			return fmt.Errorf("%w: %w", docker.ErrDeployFailed, err)
+		}
+		return nil
+	})
+}

--- a/internal/command/keys_set.go
+++ b/internal/command/keys_set.go
@@ -2,6 +2,7 @@ package command
 
 import (
 	"context"
+	"errors"
 
 	"github.com/spf13/cobra"
 
@@ -17,10 +18,11 @@ type keysSetCommand struct {
 func newKeysSetCommand() *keysSetCommand {
 	k := &keysSetCommand{}
 	k.cmd = &cobra.Command{
-		Use:   "set <host>",
-		Short: "Set secret keys and redeploy the application",
-		Args:  cobra.ExactArgs(1),
-		RunE:  WithNamespace(k.run),
+		Use:     "set <host>",
+		Short:   "Set secret keys and redeploy the application",
+		Args:    cobra.ExactArgs(1),
+		PreRunE: k.validateFlags,
+		RunE:    WithNamespace(k.run),
 	}
 
 	k.cmd.Flags().StringVar(&k.secretKeyBase, "secret-key-base", "", "new secret key base")
@@ -31,6 +33,13 @@ func newKeysSetCommand() *keysSetCommand {
 }
 
 // Private
+
+func (k *keysSetCommand) validateFlags(cmd *cobra.Command, args []string) error {
+	if cmd.Flags().Changed("secret-key-base") && k.secretKeyBase == "" {
+		return errors.New("secret key base must not be empty")
+	}
+	return nil
+}
 
 func (k *keysSetCommand) run(ctx context.Context, ns *docker.Namespace, cmd *cobra.Command, args []string) error {
 	return changeKeys(ctx, ns, args[0], "Setting keys for", func(keys *docker.Keys) error {

--- a/internal/command/keys_set.go
+++ b/internal/command/keys_set.go
@@ -2,7 +2,6 @@ package command
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/spf13/cobra"
 
@@ -34,38 +33,12 @@ func newKeysSetCommand() *keysSetCommand {
 // Private
 
 func (k *keysSetCommand) run(ctx context.Context, ns *docker.Namespace, cmd *cobra.Command, args []string) error {
-	host := args[0]
-
-	app := ns.ApplicationByHost(host)
-	if app == nil {
-		return fmt.Errorf("no application found at host %q", host)
-	}
-
-	if !app.Running {
-		return docker.ErrApplicationNotRunning
-	}
-
-	if err := ns.Setup(ctx); err != nil {
-		return fmt.Errorf("%w: %w", docker.ErrSetupFailed, err)
-	}
-
-	settings := app.Settings
-	if cmd.Flags().Changed("secret-key-base") {
-		settings.Keys.SecretKeyBase = k.secretKeyBase
-	}
-	if cmd.Flags().Changed("vapid") {
-		if err := settings.Keys.SetVAPIDKey(k.vapid); err != nil {
-			return err
+	return changeKeys(ctx, ns, args[0], "Setting keys for", func(keys *docker.Keys) error {
+		if cmd.Flags().Changed("secret-key-base") {
+			keys.SecretKeyBase = k.secretKeyBase
 		}
-	}
-
-	oldSettings := app.Settings
-	app.Settings = settings
-
-	return runWithProgress("Setting keys for "+host, func(progress docker.DeployProgressCallback) error {
-		if err := app.Deploy(ctx, progress); err != nil {
-			app.Settings = oldSettings
-			return fmt.Errorf("%w: %w", docker.ErrDeployFailed, err)
+		if cmd.Flags().Changed("vapid") {
+			return keys.SetVAPIDKey(k.vapid)
 		}
 		return nil
 	})

--- a/internal/command/keys_set.go
+++ b/internal/command/keys_set.go
@@ -1,0 +1,72 @@
+package command
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/basecamp/once/internal/docker"
+)
+
+type keysSetCommand struct {
+	cmd           *cobra.Command
+	secretKeyBase string
+	vapid         string
+}
+
+func newKeysSetCommand() *keysSetCommand {
+	k := &keysSetCommand{}
+	k.cmd = &cobra.Command{
+		Use:   "set <host>",
+		Short: "Set secret keys and redeploy the application",
+		Args:  cobra.ExactArgs(1),
+		RunE:  WithNamespace(k.run),
+	}
+
+	k.cmd.Flags().StringVar(&k.secretKeyBase, "secret-key-base", "", "new secret key base")
+	k.cmd.Flags().StringVar(&k.vapid, "vapid", "", "new VAPID private key (the public key is derived from it)")
+	k.cmd.MarkFlagsOneRequired("secret-key-base", "vapid")
+
+	return k
+}
+
+// Private
+
+func (k *keysSetCommand) run(ctx context.Context, ns *docker.Namespace, cmd *cobra.Command, args []string) error {
+	host := args[0]
+
+	app := ns.ApplicationByHost(host)
+	if app == nil {
+		return fmt.Errorf("no application found at host %q", host)
+	}
+
+	if !app.Running {
+		return docker.ErrApplicationNotRunning
+	}
+
+	if err := ns.Setup(ctx); err != nil {
+		return fmt.Errorf("%w: %w", docker.ErrSetupFailed, err)
+	}
+
+	settings := app.Settings
+	if cmd.Flags().Changed("secret-key-base") {
+		settings.Keys.SecretKeyBase = k.secretKeyBase
+	}
+	if cmd.Flags().Changed("vapid") {
+		if err := settings.Keys.SetVAPIDKey(k.vapid); err != nil {
+			return err
+		}
+	}
+
+	oldSettings := app.Settings
+	app.Settings = settings
+
+	return runWithProgress("Setting keys for "+host, func(progress docker.DeployProgressCallback) error {
+		if err := app.Deploy(ctx, progress); err != nil {
+			app.Settings = oldSettings
+			return fmt.Errorf("%w: %w", docker.ErrDeployFailed, err)
+		}
+		return nil
+	})
+}

--- a/internal/command/root.go
+++ b/internal/command/root.go
@@ -42,6 +42,7 @@ func NewRootCommand() *RootCommand {
 	r.cmd.AddCommand(newBackupCommand().cmd)
 	r.cmd.AddCommand(newDeployCommand().cmd)
 	r.cmd.AddCommand(newExecCommand().cmd)
+	r.cmd.AddCommand(newKeysCommand().cmd)
 	r.cmd.AddCommand(newListCommand().cmd)
 	r.cmd.AddCommand(newRemoveCommand().cmd)
 	r.cmd.AddCommand(newRestoreCommand().cmd)

--- a/internal/command/root.go
+++ b/internal/command/root.go
@@ -64,10 +64,18 @@ func (r *RootCommand) Execute() error {
 
 type NamespaceRunE func(ctx context.Context, ns *docker.Namespace, cmd *cobra.Command, args []string) error
 
-func withApplication(ns *docker.Namespace, host string, action string, fn func(*docker.Application) error) error {
+func findApplication(ns *docker.Namespace, host string) (*docker.Application, error) {
 	app := ns.ApplicationByHost(host)
 	if app == nil {
-		return fmt.Errorf("no application found at host %q", host)
+		return nil, fmt.Errorf("no application found at host %q", host)
+	}
+	return app, nil
+}
+
+func withApplication(ns *docker.Namespace, host string, action string, fn func(*docker.Application) error) error {
+	app, err := findApplication(ns, host)
+	if err != nil {
+		return err
 	}
 
 	if err := fn(app); err != nil {

--- a/internal/command/update.go
+++ b/internal/command/update.go
@@ -35,9 +35,9 @@ func newUpdateCommand() *updateCommand {
 func (u *updateCommand) run(ctx context.Context, ns *docker.Namespace, cmd *cobra.Command, args []string) error {
 	currentHost := args[0]
 
-	app := ns.ApplicationByHost(currentHost)
-	if app == nil {
-		return fmt.Errorf("no application found at host %q", currentHost)
+	app, err := findApplication(ns, currentHost)
+	if err != nil {
+		return err
 	}
 
 	if err := ns.Setup(ctx); err != nil {

--- a/internal/docker/application.go
+++ b/internal/docker/application.go
@@ -1,6 +1,7 @@
 package docker
 
 import (
+	"cmp"
 	"context"
 	"errors"
 	"fmt"
@@ -92,19 +93,7 @@ func (a *Application) Volume(ctx context.Context) (*ApplicationVolume, error) {
 		return nil, err
 	}
 
-	skb, err := generateSecretKeyBase()
-	if err != nil {
-		return nil, fmt.Errorf("generating secret key base: %w", err)
-	}
-	vapidPub, vapidPriv, err := generateVAPIDKeyPair()
-	if err != nil {
-		return nil, fmt.Errorf("generating VAPID key pair: %w", err)
-	}
-	return CreateVolume(ctx, a.namespace, a.Settings.Name, ApplicationVolumeSettings{
-		SecretKeyBase:   skb,
-		VAPIDPublicKey:  vapidPub,
-		VAPIDPrivateKey: vapidPriv,
-	})
+	return CreateVolume(ctx, a.namespace, a.Settings.Name, ApplicationLegacyVolumeSettings{})
 }
 
 func (a *Application) URL() string {
@@ -330,7 +319,11 @@ func (a *Application) deployWithVolume(ctx context.Context, vol *ApplicationVolu
 
 	containerName := fmt.Sprintf("%s-app-%s-%s", a.namespace.name, a.Settings.Name, id)
 
-	env := a.Settings.BuildEnv(vol.Settings)
+	if err := a.ensureKeys(vol); err != nil {
+		return err
+	}
+
+	env := a.Settings.BuildEnv()
 
 	hostConfig := &container.HostConfig{
 		RestartPolicy: container.RestartPolicy{Name: container.RestartPolicyAlways},
@@ -386,6 +379,21 @@ func (a *Application) deployWithVolume(ctx context.Context, vol *ApplicationVolu
 		progress(DeployProgress{Stage: DeployStageFinished})
 	}
 
+	return nil
+}
+
+func (a *Application) ensureKeys(vol *ApplicationVolume) error {
+	// Older installs may still have keys stored on the volume label
+	keys := cmp.Or(a.Settings.Keys, vol.Settings.Keys)
+
+	if keys.Empty() {
+		var err error
+		if keys, err = generateKeys(); err != nil {
+			return fmt.Errorf("generating keys: %w", err)
+		}
+	}
+
+	a.Settings.Keys = keys
 	return nil
 }
 

--- a/internal/docker/application.go
+++ b/internal/docker/application.go
@@ -407,8 +407,7 @@ func (a *Application) ensureKeys(vol *ApplicationVolume) error {
 	keys := cmp.Or(a.Settings.Keys, vol.Settings.Keys)
 
 	if keys.Empty() {
-		var err error
-		if keys, err = generateKeys(); err != nil {
+		if err := keys.Regenerate(true, true); err != nil {
 			return fmt.Errorf("generating keys: %w", err)
 		}
 	}

--- a/internal/docker/application.go
+++ b/internal/docker/application.go
@@ -205,6 +205,26 @@ func (a *Application) Deploy(ctx context.Context, progress DeployProgressCallbac
 	return a.deployWithVolume(ctx, vol, progress)
 }
 
+// UpdateSettings redeploys the app with the given settings. Unlike Deploy,
+// it never pulls, so the app is not updated even if its image tag has moved.
+// On failure, the previous settings are restored.
+func (a *Application) UpdateSettings(ctx context.Context, settings ApplicationSettings, progress DeployProgressCallback) error {
+	vol, err := a.Volume(ctx)
+	if err != nil {
+		return fmt.Errorf("getting volume: %w", err)
+	}
+
+	oldSettings := a.Settings
+	a.Settings = settings
+
+	if err := a.deployWithVolume(ctx, vol, progress); err != nil {
+		a.Settings = oldSettings
+		return err
+	}
+
+	return nil
+}
+
 func (a *Application) VerifyHTTPOrRemove(ctx context.Context) error {
 	if err := a.verifyHTTP(ctx); err != nil {
 		if cleanupErr := a.Remove(context.Background(), true); cleanupErr != nil {

--- a/internal/docker/application_backup.go
+++ b/internal/docker/application_backup.go
@@ -110,7 +110,7 @@ func (a *Application) TrimBackups() error {
 	return errors.Join(errs...)
 }
 
-func (a *Application) Restore(ctx context.Context, volSettings ApplicationVolumeSettings, backup io.Reader) (returnErr error) {
+func (a *Application) Restore(ctx context.Context, volSettings ApplicationLegacyVolumeSettings, backup io.Reader) (returnErr error) {
 	slog.Info("Restoring application", "app", a.Settings.Name)
 
 	defer func() {
@@ -128,6 +128,11 @@ func (a *Application) Restore(ctx context.Context, volSettings ApplicationVolume
 	vol, err := CreateVolume(ctx, a.namespace, a.Settings.Name, volSettings)
 	if err != nil {
 		return fmt.Errorf("creating volume: %w", err)
+	}
+
+	if err := a.ensureKeys(vol); err != nil {
+		vol.Destroy(ctx)
+		return err
 	}
 
 	if err := a.populateVolume(ctx, vol, backup); err != nil {
@@ -276,7 +281,7 @@ func (a *Application) runRestoreHook(ctx context.Context, vol *ApplicationVolume
 			Image:      a.Settings.Image,
 			Entrypoint: []string{},
 			Cmd:        []string{"sleep", "infinity"},
-			Env:        a.Settings.BuildEnv(vol.Settings),
+			Env:        a.Settings.BuildEnv(),
 		},
 		&container.HostConfig{Mounts: a.volumeMounts(vol)},
 		nil, nil, containerName,
@@ -359,9 +364,9 @@ func writeTarEntry(tw *tar.Writer, name string, data []byte) error {
 	return err
 }
 
-func readBackupSettings(r io.Reader) (ApplicationSettings, ApplicationVolumeSettings, error) {
+func readBackupSettings(r io.Reader) (ApplicationSettings, ApplicationLegacyVolumeSettings, error) {
 	var appSettings ApplicationSettings
-	var volSettings ApplicationVolumeSettings
+	var volSettings ApplicationLegacyVolumeSettings
 
 	gr, err := gzip.NewReader(r)
 	if err != nil {
@@ -396,7 +401,7 @@ func readBackupSettings(r io.Reader) (ApplicationSettings, ApplicationVolumeSett
 		return appSettings, volSettings, fmt.Errorf("%w: parsing application settings: %v", ErrInvalidBackup, err)
 	}
 
-	volSettings, err = UnmarshalApplicationVolumeSettings(string(volData))
+	volSettings, err = UnmarshalApplicationLegacyVolumeSettings(string(volData))
 	if err != nil {
 		return appSettings, volSettings, fmt.Errorf("%w: parsing volume settings: %v", ErrInvalidBackup, err)
 	}

--- a/internal/docker/application_settings.go
+++ b/internal/docker/application_settings.go
@@ -179,24 +179,6 @@ func (s ApplicationSettings) BuildEnv() []string {
 
 // Helpers
 
-func generateKeys() (Keys, error) {
-	skb, err := generateSecretKeyBase()
-	if err != nil {
-		return Keys{}, err
-	}
-
-	vapidPub, vapidPriv, err := generateVAPIDKeyPair()
-	if err != nil {
-		return Keys{}, err
-	}
-
-	return Keys{
-		SecretKeyBase:   skb,
-		VAPIDPublicKey:  vapidPub,
-		VAPIDPrivateKey: vapidPriv,
-	}, nil
-}
-
 func generateSecretKeyBase() (string, error) {
 	bytes := make([]byte, 32)
 	if _, err := rand.Read(bytes); err != nil {

--- a/internal/docker/application_settings.go
+++ b/internal/docker/application_settings.go
@@ -19,6 +19,27 @@ func (k Keys) Empty() bool {
 	return k == Keys{}
 }
 
+func (k *Keys) Regenerate(secretKeyBase, vapid bool) error {
+	if secretKeyBase {
+		skb, err := generateSecretKeyBase()
+		if err != nil {
+			return err
+		}
+		k.SecretKeyBase = skb
+	}
+
+	if vapid {
+		pub, priv, err := generateVAPIDKeyPair()
+		if err != nil {
+			return err
+		}
+		k.VAPIDPublicKey = pub
+		k.VAPIDPrivateKey = priv
+	}
+
+	return nil
+}
+
 type SMTPSettings struct {
 	Server   string `json:"server,omitempty"`
 	Port     string `json:"port,omitempty"`

--- a/internal/docker/application_settings.go
+++ b/internal/docker/application_settings.go
@@ -6,7 +6,9 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
+	"fmt"
 	"strconv"
+	"strings"
 )
 
 type Keys struct {
@@ -17,6 +19,18 @@ type Keys struct {
 
 func (k Keys) Empty() bool {
 	return k == Keys{}
+}
+
+func (k *Keys) SetVAPIDKey(privateKey string) error {
+	key, err := parseVAPIDPrivateKey(privateKey)
+	if err != nil {
+		return fmt.Errorf("invalid VAPID private key: %w", err)
+	}
+
+	k.VAPIDPublicKey = base64.RawURLEncoding.EncodeToString(key.PublicKey().Bytes())
+	k.VAPIDPrivateKey = base64.RawURLEncoding.EncodeToString(key.Bytes())
+
+	return nil
 }
 
 func (k *Keys) Regenerate(secretKeyBase, vapid bool) error {
@@ -201,4 +215,19 @@ func generateVAPIDKeyPair() (publicKey, privateKey string, err error) {
 	publicKey = base64.RawURLEncoding.EncodeToString(key.PublicKey().Bytes())
 
 	return publicKey, privateKey, nil
+}
+
+// parseVAPIDPrivateKey accepts any common base64 dialect (url-safe or
+// standard, padded or not) of a raw P-256 private key.
+func parseVAPIDPrivateKey(s string) (*ecdh.PrivateKey, error) {
+	s = strings.TrimSpace(s)
+	s = strings.NewReplacer("+", "-", "/", "_").Replace(s)
+	s = strings.TrimRight(s, "=")
+
+	bytes, err := base64.RawURLEncoding.DecodeString(s)
+	if err != nil {
+		return nil, err
+	}
+
+	return ecdh.P256().NewPrivateKey(bytes)
 }

--- a/internal/docker/application_settings.go
+++ b/internal/docker/application_settings.go
@@ -1,9 +1,23 @@
 package docker
 
 import (
+	"crypto/ecdh"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/hex"
 	"encoding/json"
 	"strconv"
 )
+
+type Keys struct {
+	SecretKeyBase   string `json:"secretKeyBase,omitempty"`
+	VAPIDPublicKey  string `json:"vapidPublicKey,omitempty"`
+	VAPIDPrivateKey string `json:"vapidPrivateKey,omitempty"`
+}
+
+func (k Keys) Empty() bool {
+	return k == Keys{}
+}
 
 type SMTPSettings struct {
 	Server   string `json:"server,omitempty"`
@@ -46,6 +60,7 @@ type ApplicationSettings struct {
 	Resources  ContainerResources `json:"resources"`
 	AutoUpdate bool               `json:"autoUpdate"`
 	Backup     BackupSettings     `json:"backup"`
+	Keys       Keys               `json:"keys"`
 }
 
 func UnmarshalApplicationSettings(s string) (ApplicationSettings, error) {
@@ -89,6 +104,9 @@ func (s ApplicationSettings) Equal(other ApplicationSettings) bool {
 	if s.Backup != other.Backup {
 		return false
 	}
+	if s.Keys != other.Keys {
+		return false
+	}
 	if len(s.EnvVars) != len(other.EnvVars) {
 		return false
 	}
@@ -100,11 +118,11 @@ func (s ApplicationSettings) Equal(other ApplicationSettings) bool {
 	return true
 }
 
-func (s ApplicationSettings) BuildEnv(vol ApplicationVolumeSettings) []string {
+func (s ApplicationSettings) BuildEnv() []string {
 	env := []string{
-		"SECRET_KEY_BASE=" + vol.SecretKeyBase,
-		"VAPID_PUBLIC_KEY=" + vol.VAPIDPublicKey,
-		"VAPID_PRIVATE_KEY=" + vol.VAPIDPrivateKey,
+		"SECRET_KEY_BASE=" + s.Keys.SecretKeyBase,
+		"VAPID_PUBLIC_KEY=" + s.Keys.VAPIDPublicKey,
+		"VAPID_PRIVATE_KEY=" + s.Keys.VAPIDPrivateKey,
 	}
 
 	if !s.TLSEnabled() {
@@ -122,4 +140,44 @@ func (s ApplicationSettings) BuildEnv(vol ApplicationVolumeSettings) []string {
 	}
 
 	return env
+}
+
+// Helpers
+
+func generateKeys() (Keys, error) {
+	skb, err := generateSecretKeyBase()
+	if err != nil {
+		return Keys{}, err
+	}
+
+	vapidPub, vapidPriv, err := generateVAPIDKeyPair()
+	if err != nil {
+		return Keys{}, err
+	}
+
+	return Keys{
+		SecretKeyBase:   skb,
+		VAPIDPublicKey:  vapidPub,
+		VAPIDPrivateKey: vapidPriv,
+	}, nil
+}
+
+func generateSecretKeyBase() (string, error) {
+	bytes := make([]byte, 32)
+	if _, err := rand.Read(bytes); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(bytes), nil
+}
+
+func generateVAPIDKeyPair() (publicKey, privateKey string, err error) {
+	key, err := ecdh.P256().GenerateKey(rand.Reader)
+	if err != nil {
+		return "", "", err
+	}
+
+	privateKey = base64.RawURLEncoding.EncodeToString(key.Bytes())
+	publicKey = base64.RawURLEncoding.EncodeToString(key.PublicKey().Bytes())
+
+	return publicKey, privateKey, nil
 }

--- a/internal/docker/application_settings_test.go
+++ b/internal/docker/application_settings_test.go
@@ -1,11 +1,38 @@
 package docker
 
 import (
+	"encoding/base64"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestGenerateVAPIDKeyPair(t *testing.T) {
+	pub, priv, err := generateVAPIDKeyPair()
+	require.NoError(t, err)
+	assert.NotEmpty(t, pub)
+	assert.NotEmpty(t, priv)
+
+	pubBytes, err := base64.RawURLEncoding.DecodeString(pub)
+	require.NoError(t, err)
+	assert.Len(t, pubBytes, 65)
+
+	privBytes, err := base64.RawURLEncoding.DecodeString(priv)
+	require.NoError(t, err)
+	assert.Len(t, privBytes, 32)
+}
+
+func TestGenerateVAPIDKeyPairUniqueness(t *testing.T) {
+	pub1, priv1, err := generateVAPIDKeyPair()
+	require.NoError(t, err)
+
+	pub2, priv2, err := generateVAPIDKeyPair()
+	require.NoError(t, err)
+
+	assert.NotEqual(t, pub1, pub2)
+	assert.NotEqual(t, priv1, priv2)
+}
 
 func TestBuildEnvWithSMTP(t *testing.T) {
 	settings := ApplicationSettings{
@@ -18,7 +45,7 @@ func TestBuildEnvWithSMTP(t *testing.T) {
 		},
 	}
 
-	env := settings.BuildEnv(ApplicationVolumeSettings{SecretKeyBase: "test-secret-key"})
+	env := settings.BuildEnv()
 
 	assert.Contains(t, env, "SMTP_ADDRESS=smtp.example.com")
 	assert.Contains(t, env, "SMTP_PORT=587")
@@ -30,7 +57,7 @@ func TestBuildEnvWithSMTP(t *testing.T) {
 func TestBuildEnvWithCPULimit(t *testing.T) {
 	settings := ApplicationSettings{Resources: ContainerResources{CPUs: 4}}
 
-	env := settings.BuildEnv(ApplicationVolumeSettings{SecretKeyBase: "test-secret-key"})
+	env := settings.BuildEnv()
 
 	assert.Contains(t, env, "NUM_CPUS=4")
 }
@@ -38,7 +65,7 @@ func TestBuildEnvWithCPULimit(t *testing.T) {
 func TestBuildEnvWithoutCPULimit(t *testing.T) {
 	settings := ApplicationSettings{}
 
-	env := settings.BuildEnv(ApplicationVolumeSettings{SecretKeyBase: "test-secret-key"})
+	env := settings.BuildEnv()
 
 	assert.NotContains(t, env, "NUM_CPUS=0")
 }
@@ -46,7 +73,7 @@ func TestBuildEnvWithoutCPULimit(t *testing.T) {
 func TestBuildEnvWithoutSMTP(t *testing.T) {
 	settings := ApplicationSettings{}
 
-	env := settings.BuildEnv(ApplicationVolumeSettings{SecretKeyBase: "test-secret-key"})
+	env := settings.BuildEnv()
 
 	for _, e := range env {
 		assert.NotContains(t, e, "SMTP_")
@@ -98,16 +125,59 @@ func TestBackupSettingsEqualDiffers(t *testing.T) {
 	assert.False(t, base.Equal(noBackup))
 }
 
-func TestBuildEnvWithVAPIDKeys(t *testing.T) {
-	settings := ApplicationSettings{}
+func TestKeysEqualDiffers(t *testing.T) {
+	base := ApplicationSettings{Name: "app", Keys: Keys{SecretKeyBase: "secret"}}
 
-	vol := ApplicationVolumeSettings{
-		SecretKeyBase:   "test-secret-key",
-		VAPIDPublicKey:  "test-vapid-public",
-		VAPIDPrivateKey: "test-vapid-private",
+	different := ApplicationSettings{Name: "app", Keys: Keys{SecretKeyBase: "rotated"}}
+	assert.False(t, base.Equal(different))
+
+	same := ApplicationSettings{Name: "app", Keys: Keys{SecretKeyBase: "secret"}}
+	assert.True(t, base.Equal(same))
+}
+
+func TestEnsureKeys(t *testing.T) {
+	newApp := func(keys Keys) *Application {
+		return NewApplication(nil, ApplicationSettings{Name: "app", Keys: keys})
 	}
-	env := settings.BuildEnv(vol)
+	volWithKeys := func(keys Keys) *ApplicationVolume {
+		return &ApplicationVolume{Settings: ApplicationLegacyVolumeSettings{Keys: keys}}
+	}
 
+	t.Run("keeps existing keys", func(t *testing.T) {
+		keys := Keys{SecretKeyBase: "existing"}
+		app := newApp(keys)
+		require.NoError(t, app.ensureKeys(volWithKeys(Keys{SecretKeyBase: "legacy"})))
+		assert.Equal(t, keys, app.Settings.Keys)
+	})
+
+	t.Run("falls back to legacy volume keys", func(t *testing.T) {
+		legacy := Keys{SecretKeyBase: "legacy", VAPIDPublicKey: "pub", VAPIDPrivateKey: "priv"}
+		app := newApp(Keys{})
+		require.NoError(t, app.ensureKeys(volWithKeys(legacy)))
+		assert.Equal(t, legacy, app.Settings.Keys)
+	})
+
+	t.Run("generates keys when none exist", func(t *testing.T) {
+		app := newApp(Keys{})
+		require.NoError(t, app.ensureKeys(volWithKeys(Keys{})))
+		assert.NotEmpty(t, app.Settings.Keys.SecretKeyBase)
+		assert.NotEmpty(t, app.Settings.Keys.VAPIDPublicKey)
+		assert.NotEmpty(t, app.Settings.Keys.VAPIDPrivateKey)
+	})
+}
+
+func TestBuildEnvWithKeys(t *testing.T) {
+	settings := ApplicationSettings{
+		Keys: Keys{
+			SecretKeyBase:   "test-secret-key",
+			VAPIDPublicKey:  "test-vapid-public",
+			VAPIDPrivateKey: "test-vapid-private",
+		},
+	}
+
+	env := settings.BuildEnv()
+
+	assert.Contains(t, env, "SECRET_KEY_BASE=test-secret-key")
 	assert.Contains(t, env, "VAPID_PUBLIC_KEY=test-vapid-public")
 	assert.Contains(t, env, "VAPID_PRIVATE_KEY=test-vapid-private")
 }
@@ -120,7 +190,7 @@ func TestBuildEnvWithEnvVars(t *testing.T) {
 		},
 	}
 
-	env := settings.BuildEnv(ApplicationVolumeSettings{SecretKeyBase: "test-secret-key"})
+	env := settings.BuildEnv()
 
 	assert.Contains(t, env, "DB_HOST=postgres.local")
 	assert.Contains(t, env, "DB_NAME=mydb")

--- a/internal/docker/application_settings_test.go
+++ b/internal/docker/application_settings_test.go
@@ -34,6 +34,45 @@ func TestGenerateVAPIDKeyPairUniqueness(t *testing.T) {
 	assert.NotEqual(t, priv1, priv2)
 }
 
+func TestKeysRegenerate(t *testing.T) {
+	original := Keys{
+		SecretKeyBase:   "original-secret",
+		VAPIDPublicKey:  "original-pub",
+		VAPIDPrivateKey: "original-priv",
+	}
+
+	t.Run("secret key base only", func(t *testing.T) {
+		keys := original
+		require.NoError(t, keys.Regenerate(true, false))
+		assert.NotEqual(t, original.SecretKeyBase, keys.SecretKeyBase)
+		assert.Len(t, keys.SecretKeyBase, 64)
+		assert.Equal(t, original.VAPIDPublicKey, keys.VAPIDPublicKey)
+		assert.Equal(t, original.VAPIDPrivateKey, keys.VAPIDPrivateKey)
+	})
+
+	t.Run("vapid only", func(t *testing.T) {
+		keys := original
+		require.NoError(t, keys.Regenerate(false, true))
+		assert.Equal(t, original.SecretKeyBase, keys.SecretKeyBase)
+		assert.NotEqual(t, original.VAPIDPublicKey, keys.VAPIDPublicKey)
+		assert.NotEqual(t, original.VAPIDPrivateKey, keys.VAPIDPrivateKey)
+	})
+
+	t.Run("both", func(t *testing.T) {
+		keys := original
+		require.NoError(t, keys.Regenerate(true, true))
+		assert.NotEqual(t, original.SecretKeyBase, keys.SecretKeyBase)
+		assert.NotEqual(t, original.VAPIDPublicKey, keys.VAPIDPublicKey)
+		assert.NotEqual(t, original.VAPIDPrivateKey, keys.VAPIDPrivateKey)
+	})
+
+	t.Run("neither", func(t *testing.T) {
+		keys := original
+		require.NoError(t, keys.Regenerate(false, false))
+		assert.Equal(t, original, keys)
+	})
+}
+
 func TestBuildEnvWithSMTP(t *testing.T) {
 	settings := ApplicationSettings{
 		SMTP: SMTPSettings{

--- a/internal/docker/application_settings_test.go
+++ b/internal/docker/application_settings_test.go
@@ -73,6 +73,60 @@ func TestKeysRegenerate(t *testing.T) {
 	})
 }
 
+func TestKeysSetVAPIDKey(t *testing.T) {
+	original := Keys{
+		SecretKeyBase:   "original-secret",
+		VAPIDPublicKey:  "original-pub",
+		VAPIDPrivateKey: "original-priv",
+	}
+
+	t.Run("derives public key", func(t *testing.T) {
+		pub, priv, err := generateVAPIDKeyPair()
+		require.NoError(t, err)
+
+		keys := original
+		require.NoError(t, keys.SetVAPIDKey(priv))
+		assert.Equal(t, original.SecretKeyBase, keys.SecretKeyBase)
+		assert.Equal(t, pub, keys.VAPIDPublicKey)
+		assert.Equal(t, priv, keys.VAPIDPrivateKey)
+	})
+
+	t.Run("normalizes base64 dialects", func(t *testing.T) {
+		pub, priv, err := generateVAPIDKeyPair()
+		require.NoError(t, err)
+
+		privBytes, err := base64.RawURLEncoding.DecodeString(priv)
+		require.NoError(t, err)
+
+		dialects := []string{
+			base64.URLEncoding.EncodeToString(privBytes),
+			base64.StdEncoding.EncodeToString(privBytes),
+			base64.RawStdEncoding.EncodeToString(privBytes),
+			" " + priv + "\n",
+		}
+
+		for _, dialect := range dialects {
+			keys := original
+			require.NoError(t, keys.SetVAPIDKey(dialect))
+			assert.Equal(t, pub, keys.VAPIDPublicKey)
+			assert.Equal(t, priv, keys.VAPIDPrivateKey)
+		}
+	})
+
+	t.Run("invalid private key", func(t *testing.T) {
+		keys := original
+		require.Error(t, keys.SetVAPIDKey("not-a-key"))
+		assert.Equal(t, original, keys)
+	})
+
+	t.Run("wrong key length", func(t *testing.T) {
+		keys := original
+		short := base64.RawURLEncoding.EncodeToString(make([]byte, 16))
+		require.Error(t, keys.SetVAPIDKey(short))
+		assert.Equal(t, original, keys)
+	})
+}
+
 func TestBuildEnvWithSMTP(t *testing.T) {
 	settings := ApplicationSettings{
 		SMTP: SMTPSettings{

--- a/internal/docker/application_settings_test.go
+++ b/internal/docker/application_settings_test.go
@@ -119,6 +119,12 @@ func TestKeysSetVAPIDKey(t *testing.T) {
 		assert.Equal(t, original, keys)
 	})
 
+	t.Run("empty private key", func(t *testing.T) {
+		keys := original
+		require.Error(t, keys.SetVAPIDKey(""))
+		assert.Equal(t, original, keys)
+	})
+
 	t.Run("wrong key length", func(t *testing.T) {
 		keys := original
 		short := base64.RawURLEncoding.EncodeToString(make([]byte, 16))

--- a/internal/docker/namespace.go
+++ b/internal/docker/namespace.go
@@ -340,7 +340,16 @@ func (n *Namespace) restoreState(ctx context.Context) error {
 	}
 
 	for _, candidate := range appsByName {
-		n.applications = append(n.applications, candidate.app)
+		app := candidate.app
+
+		// Older installs may still have keys stored on the volume label
+		if app.Settings.Keys.Empty() {
+			if vol, err := FindVolume(ctx, n, app.Settings.Name); err == nil {
+				app.Settings.Keys = vol.Settings.Keys
+			}
+		}
+
+		n.applications = append(n.applications, app)
 	}
 
 	n.sortApplications()

--- a/internal/docker/volume.go
+++ b/internal/docker/volume.go
@@ -2,10 +2,6 @@ package docker
 
 import (
 	"context"
-	"crypto/ecdh"
-	"crypto/rand"
-	"encoding/base64"
-	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -16,19 +12,17 @@ import (
 
 var ErrVolumeNotFound = errors.New("volume not found")
 
-type ApplicationVolumeSettings struct {
-	SecretKeyBase   string `json:"secretKeyBase"`
-	VAPIDPublicKey  string `json:"vapidPublicKey"`
-	VAPIDPrivateKey string `json:"vapidPrivateKey"`
+type ApplicationLegacyVolumeSettings struct {
+	Keys
 }
 
-func UnmarshalApplicationVolumeSettings(s string) (ApplicationVolumeSettings, error) {
-	var settings ApplicationVolumeSettings
+func UnmarshalApplicationLegacyVolumeSettings(s string) (ApplicationLegacyVolumeSettings, error) {
+	var settings ApplicationLegacyVolumeSettings
 	err := json.Unmarshal([]byte(s), &settings)
 	return settings, err
 }
 
-func (s ApplicationVolumeSettings) Marshal() string {
+func (s ApplicationLegacyVolumeSettings) Marshal() string {
 	b, _ := json.Marshal(s)
 	return string(b)
 }
@@ -36,11 +30,7 @@ func (s ApplicationVolumeSettings) Marshal() string {
 type ApplicationVolume struct {
 	namespace *Namespace
 	name      string
-	Settings  ApplicationVolumeSettings
-}
-
-func (v *ApplicationVolume) SecretKeyBase() string {
-	return v.Settings.SecretKeyBase
+	Settings  ApplicationLegacyVolumeSettings
 }
 
 func (v *ApplicationVolume) Name() string {
@@ -72,7 +62,7 @@ func FindVolume(ctx context.Context, ns *Namespace, name string) (*ApplicationVo
 		return nil, fmt.Errorf("volume %s exists but has no once label", volumeName)
 	}
 
-	settings, err := UnmarshalApplicationVolumeSettings(label)
+	settings, err := UnmarshalApplicationLegacyVolumeSettings(label)
 	if err != nil {
 		return nil, fmt.Errorf("parsing volume settings: %w", err)
 	}
@@ -84,7 +74,7 @@ func FindVolume(ctx context.Context, ns *Namespace, name string) (*ApplicationVo
 	}, nil
 }
 
-func CreateVolume(ctx context.Context, ns *Namespace, name string, settings ApplicationVolumeSettings) (*ApplicationVolume, error) {
+func CreateVolume(ctx context.Context, ns *Namespace, name string, settings ApplicationLegacyVolumeSettings) (*ApplicationVolume, error) {
 	volumeName := fmt.Sprintf("%s-app-%s", ns.name, name)
 
 	_, err := ns.client.VolumeCreate(ctx, volume.CreateOptions{
@@ -102,26 +92,4 @@ func CreateVolume(ctx context.Context, ns *Namespace, name string, settings Appl
 		name:      volumeName,
 		Settings:  settings,
 	}, nil
-}
-
-// Helpers
-
-func generateSecretKeyBase() (string, error) {
-	bytes := make([]byte, 32)
-	if _, err := rand.Read(bytes); err != nil {
-		return "", err
-	}
-	return hex.EncodeToString(bytes), nil
-}
-
-func generateVAPIDKeyPair() (publicKey, privateKey string, err error) {
-	key, err := ecdh.P256().GenerateKey(rand.Reader)
-	if err != nil {
-		return "", "", err
-	}
-
-	privateKey = base64.RawURLEncoding.EncodeToString(key.Bytes())
-	publicKey = base64.RawURLEncoding.EncodeToString(key.PublicKey().Bytes())
-
-	return publicKey, privateKey, nil
 }

--- a/internal/docker/volume_test.go
+++ b/internal/docker/volume_test.go
@@ -1,47 +1,30 @@
 package docker
 
 import (
-	"encoding/base64"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func TestGenerateVAPIDKeyPair(t *testing.T) {
-	pub, priv, err := generateVAPIDKeyPair()
-	require.NoError(t, err)
-	assert.NotEmpty(t, pub)
-	assert.NotEmpty(t, priv)
-
-	pubBytes, err := base64.RawURLEncoding.DecodeString(pub)
-	require.NoError(t, err)
-	assert.Len(t, pubBytes, 65)
-
-	privBytes, err := base64.RawURLEncoding.DecodeString(priv)
-	require.NoError(t, err)
-	assert.Len(t, privBytes, 32)
-}
-
-func TestGenerateVAPIDKeyPairUniqueness(t *testing.T) {
-	pub1, priv1, err := generateVAPIDKeyPair()
-	require.NoError(t, err)
-
-	pub2, priv2, err := generateVAPIDKeyPair()
-	require.NoError(t, err)
-
-	assert.NotEqual(t, pub1, pub2)
-	assert.NotEqual(t, priv1, priv2)
-}
-
 func TestVolumeSettingsMarshalRoundTrip(t *testing.T) {
-	original := ApplicationVolumeSettings{
-		SecretKeyBase:   "secret",
-		VAPIDPublicKey:  "pub123",
-		VAPIDPrivateKey: "priv456",
+	original := ApplicationLegacyVolumeSettings{
+		Keys: Keys{
+			SecretKeyBase:   "secret",
+			VAPIDPublicKey:  "pub123",
+			VAPIDPrivateKey: "priv456",
+		},
 	}
 
-	restored, err := UnmarshalApplicationVolumeSettings(original.Marshal())
+	restored, err := UnmarshalApplicationLegacyVolumeSettings(original.Marshal())
 	require.NoError(t, err)
 	assert.Equal(t, original, restored)
+}
+
+func TestVolumeSettingsUnmarshalLegacyLabel(t *testing.T) {
+	restored, err := UnmarshalApplicationLegacyVolumeSettings(`{"secretKeyBase":"secret","vapidPublicKey":"pub123","vapidPrivateKey":"priv456"}`)
+	require.NoError(t, err)
+	assert.Equal(t, "secret", restored.SecretKeyBase)
+	assert.Equal(t, "pub123", restored.VAPIDPublicKey)
+	assert.Equal(t, "priv456", restored.VAPIDPrivateKey)
 }


### PR DESCRIPTION
If a credential like `SECRET_KEY_BASE` were ever leaked, we should provide a way to reset it. Previously it wasn't very clear how to do this -- technically you could use a custom env var to shadow the generated ones, but that's non-obvious, and leaves open the question of what to put in as the new one. Same story for the VAPID keys.

To address this, we do two things:

- Move the key store away from the volume label, and into the regular application settings. Otherwise changing them requires replacing the volume, which is awkward.
- Adds two new commands:
    - `once keys reset ...` - allows resetting `SECRET_KEY_BASE` and/or VAPID keys. The values are replaced with newly-generated values, and the app is redeploying to apply the settings.
    - `once keys set ...` - similar to `reset`, but allows setting the keys to user-supplied values. In the case of VAPID, we'll accept a private key and derive the public key from it.

We prevent key updates from implicitly pulling new image versions, so that an update of a key doesn't quietly also perform an upgrade.