### PR TITLE
Stream restores instead of buffering them in RAM

### DIFF
--- a/internal/docker/application_backup.go
+++ b/internal/docker/application_backup.go
@@ -2,7 +2,6 @@ package docker
 
 import (
 	"archive/tar"
-	"bytes"
 	"compress/gzip"
 	"context"
 	"errors"
@@ -111,7 +110,7 @@ func (a *Application) TrimBackups() error {
 	return errors.Join(errs...)
 }
 
-func (a *Application) Restore(ctx context.Context, volSettings ApplicationVolumeSettings, volumeData []byte) (returnErr error) {
+func (a *Application) Restore(ctx context.Context, volSettings ApplicationVolumeSettings, backup io.Reader) (returnErr error) {
 	slog.Info("Restoring application", "app", a.Settings.Name)
 
 	defer func() {
@@ -131,7 +130,7 @@ func (a *Application) Restore(ctx context.Context, volSettings ApplicationVolume
 		return fmt.Errorf("creating volume: %w", err)
 	}
 
-	if err := a.populateVolume(ctx, vol, volumeData); err != nil {
+	if err := a.populateVolume(ctx, vol, backup); err != nil {
 		vol.Destroy(ctx)
 		return fmt.Errorf("populating volume: %w", err)
 	}
@@ -225,7 +224,7 @@ func (a *Application) copyVolumeData(ctx context.Context, containerName string, 
 	return nil
 }
 
-func (a *Application) populateVolume(ctx context.Context, vol *ApplicationVolume, data []byte) error {
+func (a *Application) populateVolume(ctx context.Context, vol *ApplicationVolume, backup io.Reader) error {
 	containerName := fmt.Sprintf("%s-restore-temp", a.namespace.name)
 
 	resp, err := a.namespace.client.ContainerCreate(ctx,
@@ -237,7 +236,7 @@ func (a *Application) populateVolume(ctx context.Context, vol *ApplicationVolume
 				{
 					Type:   mount.TypeVolume,
 					Source: vol.Name(),
-					Target: "/data",
+					Target: "/" + BackupDataDir,
 				},
 			},
 		},
@@ -255,10 +254,15 @@ func (a *Application) populateVolume(ctx context.Context, vol *ApplicationVolume
 		a.namespace.client.ContainerRemove(removeCtx, resp.ID, container.RemoveOptions{Force: true})
 	}()
 
-	if len(data) > 0 {
-		if err := a.namespace.client.CopyToContainer(ctx, resp.ID, "/", bytes.NewReader(data), container.CopyToContainerOptions{}); err != nil {
-			return fmt.Errorf("copying data to volume: %w", err)
-		}
+	pr, pw := io.Pipe()
+	defer pr.Close()
+	go func() {
+		pw.CloseWithError(streamVolumeDataEntries(backup, pw))
+	}()
+
+	// Extracting at the root places the data/ entries in the volume mount.
+	if err := a.namespace.client.CopyToContainer(ctx, resp.ID, "/", pr, container.CopyToContainerOptions{}); err != nil {
+		return fmt.Errorf("copying data to volume: %w", err)
 	}
 
 	return nil
@@ -355,7 +359,80 @@ func writeTarEntry(tw *tar.Writer, name string, data []byte) error {
 	return err
 }
 
+func readBackupSettings(r io.Reader) (ApplicationSettings, ApplicationVolumeSettings, error) {
+	var appSettings ApplicationSettings
+	var volSettings ApplicationVolumeSettings
+
+	gr, err := gzip.NewReader(r)
+	if err != nil {
+		return appSettings, volSettings, fmt.Errorf("%w: %v", ErrInvalidBackup, err)
+	}
+	defer gr.Close()
+
+	tr := tar.NewReader(gr)
+	var appData, volData []byte
+
+	for appData == nil || volData == nil {
+		header, err := tr.Next()
+		if err == nil {
+			switch header.Name {
+			case backupAppSettingsEntry:
+				appData, err = io.ReadAll(tr)
+			case backupVolSettingsEntry:
+				volData, err = io.ReadAll(tr)
+			}
+		}
+
+		if errors.Is(err, io.EOF) {
+			return appSettings, volSettings, fmt.Errorf("%w: missing required metadata files", ErrInvalidBackup)
+		}
+		if err != nil {
+			return appSettings, volSettings, fmt.Errorf("%w: %v", ErrInvalidBackup, err)
+		}
+	}
+
+	appSettings, err = UnmarshalApplicationSettings(string(appData))
+	if err != nil {
+		return appSettings, volSettings, fmt.Errorf("%w: parsing application settings: %v", ErrInvalidBackup, err)
+	}
+
+	volSettings, err = UnmarshalApplicationVolumeSettings(string(volData))
+	if err != nil {
+		return appSettings, volSettings, fmt.Errorf("%w: parsing volume settings: %v", ErrInvalidBackup, err)
+	}
+
+	return appSettings, volSettings, nil
+}
+
+func streamVolumeDataEntries(backup io.Reader, w io.Writer) error {
+	gr, err := gzip.NewReader(backup)
+	if err != nil {
+		return fmt.Errorf("%w: %v", ErrInvalidBackup, err)
+	}
+	defer gr.Close()
+
+	tw := tar.NewWriter(w)
+	err = copyTarEntries(gr, tw, func(header *tar.Header) bool {
+		return header.Name == BackupDataDir || strings.HasPrefix(header.Name, BackupDataDir+"/")
+	})
+	if err != nil {
+		return err
+	}
+	return tw.Close()
+}
+
 func copyTarEntriesWithPrefix(src io.Reader, dst *tar.Writer, oldPrefix, newPrefix string) error {
+	return copyTarEntries(src, dst, func(header *tar.Header) bool {
+		if header.Name == oldPrefix {
+			header.Name = newPrefix
+		} else if strings.HasPrefix(header.Name, oldPrefix+"/") {
+			header.Name = newPrefix + strings.TrimPrefix(header.Name, oldPrefix)
+		}
+		return true
+	})
+}
+
+func copyTarEntries(src io.Reader, dst *tar.Writer, keep func(*tar.Header) bool) error {
 	tr := tar.NewReader(src)
 	for {
 		header, err := tr.Next()
@@ -366,22 +443,15 @@ func copyTarEntriesWithPrefix(src io.Reader, dst *tar.Writer, oldPrefix, newPref
 			return err
 		}
 
-		if oldPrefix != "" && newPrefix != "" {
-			if header.Name == oldPrefix {
-				header.Name = newPrefix
-			} else if strings.HasPrefix(header.Name, oldPrefix+"/") {
-				header.Name = newPrefix + strings.TrimPrefix(header.Name, oldPrefix)
-			}
+		if !keep(header) {
+			continue
 		}
 
 		if err := dst.WriteHeader(header); err != nil {
 			return err
 		}
-
-		if header.Size > 0 {
-			if _, err := io.Copy(dst, tr); err != nil {
-				return err
-			}
+		if _, err := io.Copy(dst, tr); err != nil {
+			return err
 		}
 	}
 }

--- a/internal/docker/application_backup_test.go
+++ b/internal/docker/application_backup_test.go
@@ -142,26 +142,23 @@ func TestCopyTarEntriesWithPrefix(t *testing.T) {
 	assert.Equal(t, "data/file.txt", header.Name)
 }
 
-func TestWriteTarEntryAndCopyRoundTrip(t *testing.T) {
+func TestReadBackupSettings(t *testing.T) {
 	// Build a complete backup-like tar
 	var backupBuf bytes.Buffer
 	gw := gzip.NewWriter(&backupBuf)
 	tw := tar.NewWriter(gw)
 
+	require.NoError(t, writeTarEntry(tw, "data/file.txt", []byte("file content")))
 	require.NoError(t, writeTarEntry(tw, backupAppSettingsEntry, []byte(`{"name":"app"}`)))
 	require.NoError(t, writeTarEntry(tw, backupVolSettingsEntry, []byte(`{"secretKeyBase":"secret","vapidPublicKey":"pub123","vapidPrivateKey":"priv456"}`)))
-	require.NoError(t, writeTarEntry(tw, "data/file.txt", []byte("file content")))
 
 	require.NoError(t, tw.Close())
 	require.NoError(t, gw.Close())
 
-	// Parse the backup
-	ns := &Namespace{name: "test"}
-	appSettings, volSettings, volumeData, err := ns.parseBackup(&backupBuf)
+	appSettings, volSettings, err := readBackupSettings(&backupBuf)
 	require.NoError(t, err)
 	assert.Equal(t, "app", appSettings.Name)
 	assert.Equal(t, "secret", volSettings.SecretKeyBase)
 	assert.Equal(t, "pub123", volSettings.VAPIDPublicKey)
 	assert.Equal(t, "priv456", volSettings.VAPIDPrivateKey)
-	assert.NotEmpty(t, volumeData)
 }

--- a/internal/docker/namespace.go
+++ b/internal/docker/namespace.go
@@ -1,9 +1,6 @@
 package docker
 
 import (
-	"archive/tar"
-	"bytes"
-	"compress/gzip"
 	"context"
 	"errors"
 	"fmt"
@@ -226,8 +223,8 @@ func (n *Namespace) SaveState(ctx context.Context, state *State) error {
 	return n.proxy.SaveState(ctx, state)
 }
 
-func (n *Namespace) Restore(ctx context.Context, r io.Reader) (*Application, error) {
-	appSettings, volSettings, volumeData, err := n.parseBackup(r)
+func (n *Namespace) Restore(ctx context.Context, r io.ReadSeeker) (*Application, error) {
+	appSettings, volSettings, err := readBackupSettings(r)
 	if err != nil {
 		return nil, fmt.Errorf("parsing backup: %w", err)
 	}
@@ -242,8 +239,12 @@ func (n *Namespace) Restore(ctx context.Context, r io.Reader) (*Application, err
 	}
 	appSettings.Name = name
 
+	if _, err := r.Seek(0, io.SeekStart); err != nil {
+		return nil, fmt.Errorf("rewinding backup: %w", err)
+	}
+
 	app := NewApplication(n, appSettings)
-	if err := app.Restore(ctx, volSettings, volumeData); err != nil {
+	if err := app.Restore(ctx, volSettings, r); err != nil {
 		if cleanupErr := app.Destroy(context.Background(), true); cleanupErr != nil {
 			slog.Error("Failed to clean up after restore failure", "app", appSettings.Name, "error", cleanupErr)
 		}
@@ -350,83 +351,6 @@ func (n *Namespace) sortApplications() {
 	slices.SortFunc(n.applications, func(a, b *Application) int {
 		return strings.Compare(a.Settings.Host, b.Settings.Host)
 	})
-}
-
-func (n *Namespace) parseBackup(r io.Reader) (ApplicationSettings, ApplicationVolumeSettings, []byte, error) {
-	var appSettings ApplicationSettings
-	var volSettings ApplicationVolumeSettings
-	var volumeData bytes.Buffer
-
-	gr, err := gzip.NewReader(r)
-	if err != nil {
-		return appSettings, volSettings, nil, fmt.Errorf("%w: %v", ErrInvalidBackup, err)
-	}
-	defer gr.Close()
-
-	tr := tar.NewReader(gr)
-	tw := tar.NewWriter(&volumeData)
-	defer tw.Close()
-
-	foundApp := false
-	foundVol := false
-
-	for {
-		header, err := tr.Next()
-		if errors.Is(err, io.EOF) {
-			break
-		}
-		if err != nil {
-			return appSettings, volSettings, nil, fmt.Errorf("%w: %v", ErrInvalidBackup, err)
-		}
-
-		switch header.Name {
-		case backupAppSettingsEntry:
-			data, err := io.ReadAll(tr)
-			if err != nil {
-				return appSettings, volSettings, nil, fmt.Errorf("%w: reading application settings: %v", ErrInvalidBackup, err)
-			}
-			appSettings, err = UnmarshalApplicationSettings(string(data))
-			if err != nil {
-				return appSettings, volSettings, nil, fmt.Errorf("%w: parsing application settings: %v", ErrInvalidBackup, err)
-			}
-			foundApp = true
-
-		case backupVolSettingsEntry:
-			data, err := io.ReadAll(tr)
-			if err != nil {
-				return appSettings, volSettings, nil, fmt.Errorf("%w: reading volume settings: %v", ErrInvalidBackup, err)
-			}
-			volSettings, err = UnmarshalApplicationVolumeSettings(string(data))
-			if err != nil {
-				return appSettings, volSettings, nil, fmt.Errorf("%w: parsing volume settings: %v", ErrInvalidBackup, err)
-			}
-			foundVol = true
-
-		default:
-			if header.Name == BackupDataDir || strings.HasPrefix(header.Name, BackupDataDir+"/") {
-				newHeader := *header
-				if header.Name == BackupDataDir {
-					newHeader.Name = "data"
-				} else {
-					newHeader.Name = "data" + strings.TrimPrefix(header.Name, BackupDataDir)
-				}
-				if err := tw.WriteHeader(&newHeader); err != nil {
-					return appSettings, volSettings, nil, err
-				}
-				if header.Size > 0 {
-					if _, err := io.Copy(tw, tr); err != nil {
-						return appSettings, volSettings, nil, err
-					}
-				}
-			}
-		}
-	}
-
-	if !foundApp || !foundVol {
-		return appSettings, volSettings, nil, fmt.Errorf("%w: missing required metadata files", ErrInvalidBackup)
-	}
-
-	return appSettings, volSettings, volumeData.Bytes(), nil
 }
 
 // Helpers


### PR DESCRIPTION
When restoring a backup, we had been reading the entire archive into memory before extracting the metadata and populating the volume. For a large backup this would be problematic.

Instead, let's stream the contents in, file at a time.