### PR TITLE
Publish test fixture images without the daemon

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -48,6 +48,7 @@ require (
 	github.com/go-ole/go-ole v1.3.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/kamstrup/intmap v0.5.2 // indirect
+	github.com/klauspost/compress v1.18.6 // indirect
 	github.com/lufia/plan9stats v0.0.0-20260330125221-c963978e514e // indirect
 	github.com/moby/docker-image-spec v1.3.1 // indirect
 	github.com/moby/sys/atomicwriter v0.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -85,6 +85,8 @@ github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/kamstrup/intmap v0.5.2 h1:qnwBm1mh4XAnW9W9Ue9tZtTff8pS6+s6iKF6JRIV2Dk=
 github.com/kamstrup/intmap v0.5.2/go.mod h1:gWUVWHKzWj8xpJVFf5GC0O26bWmv3GqdnIX/LMT6Aq4=
+github.com/klauspost/compress v1.18.6 h1:2jupLlAwFm95+YDR+NwD2MEfFO9d4z4Prjl1XXDjuao=
+github.com/klauspost/compress v1.18.6/go.mod h1:cwPg85FWrGar70rWktvGQj8/hthj3wpl0PGDogxkrSQ=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=

--- a/integration/docker_test.go
+++ b/integration/docker_test.go
@@ -20,13 +20,17 @@ import (
 	"testing"
 	"time"
 
-	"github.com/docker/docker/api/types/build"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/events"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/client"
 	"github.com/docker/go-connections/nat"
+	"github.com/google/go-containerregistry/pkg/name"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/mutate"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
+	"github.com/google/go-containerregistry/pkg/v1/tarball"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -241,8 +245,8 @@ func TestUpdateDetectsLocalImageChange(t *testing.T) {
 	firstContainer, err := app.ContainerName(ctx)
 	require.NoError(t, err)
 
-	// Build v2 with the same tag. The local tag now points to a newer image
-	// than what the running container uses.
+	// Push v2 with the same tag. The registry now holds a newer image than
+	// what the running container uses.
 	buildAndPushImage(t, ctx, imageTag, "v2")
 
 	changed, err := app.Update(ctx, nil)
@@ -1306,45 +1310,51 @@ func startLocalRegistry(t *testing.T, ctx context.Context) string {
 	return registryURL
 }
 
-func buildHookImage(t *testing.T, ctx context.Context, registryURL, name, hookScript string) string {
+// Derived test images are assembled with go-containerregistry and written
+// straight to the local registry, keeping the docker daemon out of the
+// publishing path. Pushing through the daemon breaks when its containerd
+// store holds a layer's content without the compressed blob a manifest
+// references (moby/moby#49784).
+func buildHookImage(t *testing.T, ctx context.Context, registryURL, imageName, hookScript string) string {
 	t.Helper()
-	c, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
-	require.NoError(t, err)
-	defer c.Close()
-
-	dockerfile := fmt.Sprintf("FROM %s\nCOPY post-restore /hooks/post-restore\n", integrationAppImageRef)
 
 	var buf bytes.Buffer
 	tw := tar.NewWriter(&buf)
-	addTarEntry := func(name string, data []byte) {
-		require.NoError(t, tw.WriteHeader(&tar.Header{Name: name, Size: int64(len(data)), Mode: 0o644}))
-		_, err := tw.Write(data)
-		require.NoError(t, err)
-	}
-	addTarEntry("Dockerfile", []byte(dockerfile))
-
-	require.NoError(t, tw.WriteHeader(&tar.Header{Name: "post-restore", Size: int64(len(hookScript)), Mode: 0o755}))
-	_, err = tw.Write([]byte(hookScript))
+	require.NoError(t, tw.WriteHeader(&tar.Header{Name: "hooks/", Typeflag: tar.TypeDir, Mode: 0o755}))
+	require.NoError(t, tw.WriteHeader(&tar.Header{Name: "hooks/post-restore", Size: int64(len(hookScript)), Mode: 0o755}))
+	_, err := tw.Write([]byte(hookScript))
 	require.NoError(t, err)
 	require.NoError(t, tw.Close())
 
-	fullTag := registryURL + "/" + name + ":latest"
-
-	buildResp, err := c.ImageBuild(ctx, &buf, build.ImageBuildOptions{
-		Tags:       []string{fullTag},
-		Dockerfile: "Dockerfile",
-		Remove:     true,
+	layer, err := tarball.LayerFromOpener(func() (io.ReadCloser, error) {
+		return io.NopCloser(bytes.NewReader(buf.Bytes())), nil
 	})
 	require.NoError(t, err)
-	io.Copy(io.Discard, buildResp.Body)
-	buildResp.Body.Close()
 
-	pushResp, err := c.ImagePush(ctx, fullTag, image.PushOptions{RegistryAuth: "e30="}) // base64 "{}"
+	img, err := mutate.AppendLayers(baseImage(t, ctx), layer)
 	require.NoError(t, err)
-	io.Copy(io.Discard, pushResp)
-	pushResp.Close()
 
+	fullTag := registryURL + "/" + imageName + ":latest"
+	pushToRegistry(t, ctx, fullTag, img)
 	return fullTag
+}
+
+func baseImage(t *testing.T, ctx context.Context) v1.Image {
+	t.Helper()
+
+	ref, err := name.ParseReference(integrationAppImageRef)
+	require.NoError(t, err)
+	img, err := remote.Image(ref, remote.WithContext(ctx))
+	require.NoError(t, err)
+	return img
+}
+
+func pushToRegistry(t *testing.T, ctx context.Context, tag string, img v1.Image) {
+	t.Helper()
+
+	ref, err := name.ParseReference(tag)
+	require.NoError(t, err)
+	require.NoError(t, remote.Write(ref, img, remote.WithContext(ctx)))
 }
 
 func buildTestBackup(t *testing.T, imageName string) []byte {
@@ -1446,30 +1456,19 @@ func extractTarGz(t *testing.T, r io.Reader) map[string][]byte {
 
 func buildAndPushImage(t *testing.T, ctx context.Context, tag, version string) {
 	t.Helper()
-	c, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
-	require.NoError(t, err)
-	defer c.Close()
 
-	dockerfile := fmt.Sprintf("FROM %s\nLABEL version=%s\n", integrationAppImageRef, version)
-
-	var buf bytes.Buffer
-	tw := tar.NewWriter(&buf)
-	require.NoError(t, tw.WriteHeader(&tar.Header{Name: "Dockerfile", Size: int64(len(dockerfile)), Mode: 0o644}))
-	_, err = tw.Write([]byte(dockerfile))
+	base := baseImage(t, ctx)
+	cfg, err := base.ConfigFile()
 	require.NoError(t, err)
-	require.NoError(t, tw.Close())
 
-	buildResp, err := c.ImageBuild(ctx, &buf, build.ImageBuildOptions{
-		Tags:       []string{tag},
-		Dockerfile: "Dockerfile",
-		Remove:     true,
-	})
-	require.NoError(t, err)
-	io.Copy(io.Discard, buildResp.Body)
-	buildResp.Body.Close()
+	cfg = cfg.DeepCopy()
+	if cfg.Config.Labels == nil {
+		cfg.Config.Labels = map[string]string{}
+	}
+	cfg.Config.Labels["version"] = version
 
-	pushResp, err := c.ImagePush(ctx, tag, image.PushOptions{RegistryAuth: "e30="})
+	img, err := mutate.ConfigFile(base, cfg)
 	require.NoError(t, err)
-	io.Copy(io.Discard, pushResp)
-	pushResp.Close()
+
+	pushToRegistry(t, ctx, tag, img)
 }


### PR DESCRIPTION
The integration tests built derived images with the docker daemon and pushed them to a throwaway local registry. With the containerd image store, a pull skips downloading a layer blob when the layer's content already exists locally (moby/moby#49784), so those pushes failed whenever the base image's layers were present from another source: a local build of the test image, the build cache, or any other Debian-based image.

Assemble the derived images with go-containerregistry instead, and write them directly to the registry. The daemon now only pulls images, which matches what the product does in production.