### PR TITLE
feat: add native Screenote installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,8 @@ These include:
 By convention, Rails applications use this as the base for cryptographic signing.
 - `DISABLE_SSL` -- This will be set to `true` if the app is running without SSL.
 This can be useful for applications that generate redirects or URLs that would otherwise assume SSL is being used.
+- `ONCE_HOST` -- The hostname selected for the application.
+This lets applications generate canonical URLs without asking for the hostname a second time.
 - `VAPID_PUBLIC_KEY`/`VAPID_PRIVATE_KEY` -- For applications the use WebPush, unique VAPID credentials are automatically generated and passed in these variables.
 - `SMTP_ADDRESS`/`SMTP_PORT`/`SMTP_USERNAME`/`SMTP_PASSWORD`/`MAILER_FROM_ADDRESS` -- The values from the Email Settings screen are passed in these.
 - `NUM_CPUS` -- If an application is restricted with a CPU quota, this variable will contain the number of CPUs it has been allowed to use.

--- a/installer/main.go
+++ b/installer/main.go
@@ -21,6 +21,10 @@ type InstallScriptArgs struct {
 	ImageRef string
 }
 
+var installImageAliases = map[string]string{
+	"screenote": "ghcr.io/ivankuznetsov/screenote",
+}
+
 func withLogging(h http.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		start := time.Now()
@@ -76,7 +80,7 @@ func healthHandler(w http.ResponseWriter, r *http.Request) {
 
 func newInstallScriptHandler(template *template.Template) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		imageRef := r.PathValue("image")
+		imageRef := expandInstallImageAlias(r.PathValue("image"))
 		if imageRef != "" {
 			if _, err := reference.ParseNormalizedNamed(imageRef); err != nil {
 				http.Error(w, "invalid image reference", http.StatusBadRequest)
@@ -93,6 +97,14 @@ func newInstallScriptHandler(template *template.Template) http.HandlerFunc {
 			slog.Error("Failed to execute template", "error", err)
 		}
 	}
+}
+
+func expandInstallImageAlias(imageRef string) string {
+	if expanded, ok := installImageAliases[imageRef]; ok {
+		return expanded
+	}
+
+	return imageRef
 }
 
 func main() {

--- a/installer/main_test.go
+++ b/installer/main_test.go
@@ -54,6 +54,16 @@ func TestInstallScriptHandler_EmptyImageRef(t *testing.T) {
 	assert.Equal(t, http.StatusOK, w.Code)
 }
 
+func TestInstallScriptHandler_ExpandsScreenoteForOlderClients(t *testing.T) {
+	handler := testHandler()
+
+	w := serve(handler, "screenote")
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), "IMAGE_REF='ghcr.io/ivankuznetsov/screenote'")
+	assert.NotContains(t, w.Body.String(), "IMAGE_REF='screenote'")
+}
+
 // Helpers
 
 func testHandler() http.HandlerFunc {

--- a/internal/docker/application_settings.go
+++ b/internal/docker/application_settings.go
@@ -159,6 +159,9 @@ func (s ApplicationSettings) BuildEnv() []string {
 		"VAPID_PUBLIC_KEY=" + s.Keys.VAPIDPublicKey,
 		"VAPID_PRIVATE_KEY=" + s.Keys.VAPIDPrivateKey,
 	}
+	if s.Host != "" {
+		env = append(env, "ONCE_HOST="+s.Host)
+	}
 
 	if !s.TLSEnabled() {
 		env = append(env, "DISABLE_SSL=true")
@@ -171,6 +174,9 @@ func (s ApplicationSettings) BuildEnv() []string {
 	env = append(env, s.SMTP.BuildEnv()...)
 
 	for k, v := range s.EnvVars {
+		if k == "ONCE_HOST" {
+			continue
+		}
 		env = append(env, k+"="+v)
 	}
 

--- a/internal/docker/application_settings_test.go
+++ b/internal/docker/application_settings_test.go
@@ -2,6 +2,7 @@ package docker
 
 import (
 	"encoding/base64"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -159,6 +160,25 @@ func TestBuildEnvWithCPULimit(t *testing.T) {
 	env := settings.BuildEnv()
 
 	assert.Contains(t, env, "NUM_CPUS=4")
+}
+
+func TestBuildEnvWithApplicationHost(t *testing.T) {
+	settings := ApplicationSettings{
+		Host:    "screenote.example.com",
+		EnvVars: map[string]string{"ONCE_HOST": "spoofed.example.com"},
+	}
+
+	env := settings.BuildEnv()
+
+	assert.Contains(t, env, "ONCE_HOST=screenote.example.com")
+	assert.NotContains(t, env, "ONCE_HOST=spoofed.example.com")
+	count := 0
+	for _, value := range env {
+		if strings.HasPrefix(value, "ONCE_HOST=") {
+			count++
+		}
+	}
+	assert.Equal(t, 1, count)
 }
 
 func TestBuildEnvWithoutCPULimit(t *testing.T) {

--- a/internal/ui/install_app_list.go
+++ b/internal/ui/install_app_list.go
@@ -16,6 +16,7 @@ type KnownApp struct {
 var knownApps = []KnownApp{
 	{Name: "Campfire", Alias: "campfire", ImageRef: "ghcr.io/basecamp/once-campfire"},
 	{Name: "Fizzy", Alias: "fizzy", ImageRef: "ghcr.io/basecamp/fizzy"},
+	{Name: "Screenote", Alias: "screenote", ImageRef: "ghcr.io/ivankuznetsov/screenote"},
 	{Name: "Writebook", Alias: "writebook", ImageRef: "ghcr.io/basecamp/writebook"},
 }
 

--- a/internal/ui/install_app_list_test.go
+++ b/internal/ui/install_app_list_test.go
@@ -64,6 +64,7 @@ func TestInstallAppList_View(t *testing.T) {
 	assert.Contains(t, view, "Choose an application")
 	assert.Contains(t, view, "Campfire")
 	assert.Contains(t, view, "Fizzy")
+	assert.Contains(t, view, "Screenote")
 	assert.Contains(t, view, "Writebook")
 	assert.Contains(t, view, "Custom Docker image")
 }
@@ -80,6 +81,10 @@ func TestExpandAlias(t *testing.T) {
 	ref, ok = expandAlias("writebook")
 	assert.True(t, ok)
 	assert.Equal(t, "ghcr.io/basecamp/writebook", ref)
+
+	ref, ok = expandAlias("screenote")
+	assert.True(t, ok)
+	assert.Equal(t, "ghcr.io/ivankuznetsov/screenote", ref)
 
 	ref, ok = expandAlias("ghcr.io/basecamp/once-campfire:latest")
 	assert.False(t, ok)


### PR DESCRIPTION
## Summary

Screenote can use ONCE's native application flow: `curl https://get.once.com/screenote | sh` resolves to its published image, Screenote appears in the app picker, and the container receives the hostname selected by the operator.

`ONCE_HOST` is generated by ONCE and cannot be overridden through custom environment settings. The installer also expands the `screenote` shortcut server-side, so the one-line route still works when the machine already has an older ONCE binary that does not know the catalog alias.

## Validation

- `go test ./internal/background ./internal/command ./internal/docker ./internal/ui`
- `cd installer && go test ./...`
- Exercised Screenote deploy, first-run setup, restart, bare update, and persistence locally with the patched ONCE binary
