### PR TITLE
Correct the stale setup-go version comment in release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
         persist-credentials: false
 
     - name: Set up Go
-      uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v5.6.0 # zizmor: ignore[cache-poisoning] -- cache is branch-isolated; fork PRs cannot write to this cache
+      uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0 # zizmor: ignore[cache-poisoning] -- cache is branch-isolated; fork PRs cannot write to this cache
       with:
         go-version-file: go.mod
 


### PR DESCRIPTION
Follow-up to #84, which I merged today. It bumped this pin from v5.6.0 to v7.0.0 but left the comment reading `# v5.6.0`:

```yaml
uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v5.6.0 # zizmor: ignore[cache-poisoning] -- ...
```

`b7ad1dad` is tagged `v7` and `v7.0.0`; v5.6.0 is `40f1582b`. `ci.yml` already labels the same SHA `v7.0.0`, so the two files disagreed.

**Comment only — the pin is unchanged.** The job has been running setup-go v7.0.0 since #84 merged either way; this just makes the file say so.

Two things let it through, both worth knowing:

- Dependabot rewrites a bare `# vX.Y.Z` comment on a SHA-pinned `uses:` line, but not when a second comment follows it — here the standalone `zizmor: ignore`. `ci.yml`'s copy of the same line has no trailing comment and was updated correctly.
- zizmor's `ref-version-mismatch` (new in 1.29.0, which this repo now runs via zizmor-action v0.6.2) doesn't catch it either: with the trailing comment it can't parse a version out of the line, so the audit stays silent rather than firing. Verified — `zizmor --persona=regular` online reports no findings both before and after this change.

So neither the bumper nor the linter covers the compound-comment case. `basecamp/.github` has a reusable `dependabot-sync-actions-comments.yml` that names exactly this ("future compound comments") as what its post-merge repair pass is for, but this repo doesn't wire up the caller. Adopting it needs a deploy key and a `dependabot-sync` environment, so I've left that as a separate decision rather than folding it in here.