### PR TITLE
Run govulncheck on a schedule

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -53,15 +53,17 @@ jobs:
       # honestly. Revisit when moby/moby/v2 is stable.
       ACCEPTED: "GO-2026-4887 GO-2026-4883"
     steps:
-      # Always scan the default branch, including on workflow_dispatch: what we
-      # ship is what needs scanning, and pinning it keeps this to one tracking
-      # issue rather than one per dispatched ref. Note this pins the source tree
-      # only -- GitHub loads the workflow definition itself from the dispatched
-      # ref, which is why the reporting step checks it is the canonical run
-      # before touching the issue.
+      # No ref: on purpose. With none given, checkout pins to the SHA that
+      # triggered the run, so the tree and the workflow definition are the same
+      # commit -- a push that adds a module and its SCAN_MATRIX entry together
+      # can never be scanned with the previous matrix. Naming the branch instead
+      # would follow the moving tip and reintroduce exactly that gap.
+      #
+      # Scheduled runs only ever trigger on the default branch, which is what we
+      # ship. A workflow_dispatch from elsewhere scans its own ref, and the
+      # reporting step declines to touch the tracking issue for those.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ github.event.repository.default_branch }}
           persist-credentials: false
 
       - name: Record the scanned commit

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -97,11 +97,8 @@ jobs:
 
           cat "${RUNNER_TEMP}/report.txt"
 
-          if [ "${scan_error}" -eq 1 ]; then
-            echo "outcome=error" >> "$GITHUB_OUTPUT"
-            echo "govulncheck failed to run; see above." >&2
-            exit 1
-          fi
+          # A failed target must not bury a real finding from a target that succeeded, so
+          # always filter whatever JSON was produced before deciding what to report.
 
           # Fail on findings govulncheck considers reachable (a symbol-level trace) that
           # are not in ACCEPTED -- the same set its "Your code is affected by N
@@ -189,10 +186,23 @@ jobs:
               print("\n".join(problems))
           PY
 
+          findings=0
           if [ -s "${RUNNER_TEMP}/new.txt" ]; then
-            echo "outcome=vulnerable" >> "$GITHUB_OUTPUT"
+            findings=1
             echo "Actionable findings:"
             cat "${RUNNER_TEMP}/new.txt"
+          fi
+
+          if [ "${scan_error}" -eq 1 ] && [ "${findings}" -eq 1 ]; then
+            echo "outcome=vulnerable-and-error" >> "$GITHUB_OUTPUT"
+            echo "govulncheck also failed to run for at least one target/module; see above." >&2
+            exit 1
+          elif [ "${scan_error}" -eq 1 ]; then
+            echo "outcome=error" >> "$GITHUB_OUTPUT"
+            echo "govulncheck failed to run for at least one target/module; see above." >&2
+            exit 1
+          elif [ "${findings}" -eq 1 ]; then
+            echo "outcome=vulnerable" >> "$GITHUB_OUTPUT"
             exit 1
           fi
           echo "outcome=clean" >> "$GITHUB_OUTPUT"
@@ -240,7 +250,9 @@ jobs:
             body_output="(govulncheck produced no output -- the job failed before or during the scan; see the run log.)"
           fi
 
-          if [ "${OUTCOME}" = "error" ]; then
+          if [ "${OUTCOME}" = "vulnerable-and-error" ]; then
+            headline="The scheduled \`govulncheck\` run found vulnerabilities that are not in this workflow's accepted list, **and** failed to scan at least one target or module. Both need attention: the findings below are real, and the coverage gap means there may be more."
+          elif [ "${OUTCOME}" = "error" ]; then
             headline="The scheduled \`govulncheck\` run **could not complete**. This is a scanner or environment failure, not a vulnerability report."
           elif [ "${OUTCOME}" = "vulnerable" ]; then
             headline="The scheduled \`govulncheck\` run found vulnerabilities that are not in this workflow's accepted list."

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,126 @@
+name: Security
+
+# Toolchain and dependency advisories are published against code that has not
+# changed, so this runs on a clock rather than on a diff. Gating pull requests
+# on it would turn every newly published CVE into a red build on unrelated work.
+on:
+  schedule:
+    - cron: '31 6 * * *'
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  govulncheck:
+    name: Govulncheck
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    env:
+      # Findings we have looked at and are choosing to carry, so the run stays
+      # quiet until something NEW appears. Everything else fails the job.
+      #
+      # GO-2026-4887  Moby AuthZ plugin bypass on oversized request bodies
+      # GO-2026-4883  Moby off-by-one in plugin privilege validation
+      #
+      # Both are in github.com/docker/docker, which reports "Fixed in: N/A" --
+      # the fix exists only in github.com/moby/moby/v2 >= 2.0.0-beta.8, a
+      # module-path migration onto a beta.
+      #
+      # govulncheck reports these as reachable across most of the docker client
+      # surface we use, so treat that as "we link the module", not as a specific
+      # exploitable path: both bugs are in the *daemon's* plugin authorization,
+      # and we are a client of the daemon, not a host of it.
+      #
+      # Revisit when moby/moby/v2 is stable.
+      ACCEPTED: "GO-2026-4887 GO-2026-4883"
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
+
+      - name: Install govulncheck
+        run: go install golang.org/x/vuln/cmd/govulncheck@latest
+
+      - name: Run govulncheck
+        id: scan
+        run: |
+          govulncheck -format json ./... > "${RUNNER_TEMP}/govulncheck.json"
+          govulncheck ./... > "${RUNNER_TEMP}/govulncheck.txt" 2>&1 || true
+          cat "${RUNNER_TEMP}/govulncheck.txt"
+
+          # Fail only on findings govulncheck considers reachable (a symbol-level
+          # trace) that are not in ACCEPTED. This is the same set its own
+          # "Your code is affected by N vulnerabilities" line counts.
+          new=$(python3 - "$ACCEPTED" <<'PY'
+          import json, os, sys
+          accepted = {x for x in sys.argv[1].split() if x}
+          raw = open(os.environ["RUNNER_TEMP"] + "/govulncheck.json").read()
+          dec, i, reachable = json.JSONDecoder(), 0, set()
+          while i < len(raw):
+              while i < len(raw) and raw[i].isspace(): i += 1
+              if i >= len(raw): break
+              obj, i = dec.raw_decode(raw, i)
+              f = obj.get("finding")
+              if f and (f.get("trace") or [{}])[0].get("function"):
+                  reachable.add(f["osv"])
+          print("\n".join(sorted(reachable - accepted)))
+          PY
+          )
+          if [ -n "$new" ]; then
+            echo "New reachable vulnerabilities:"
+            echo "$new"
+            echo "$new" > "${RUNNER_TEMP}/new.txt"
+            exit 1
+          fi
+          echo "No new reachable vulnerabilities (accepted: ${ACCEPTED:-none})."
+
+      - name: Summarize
+        if: always()
+        run: |
+          {
+            echo '## govulncheck'
+            echo
+            echo '```'
+            cat "${RUNNER_TEMP}/govulncheck.txt"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      # A scheduled job that only goes red in the Actions tab is the same silence
+      # this workflow exists to end, so failures open an issue. One at a time:
+      # if a govulncheck issue is already open, the finding is already visible.
+      - name: Report
+        if: failure() && steps.scan.outcome == 'failure'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          if [ -n "$(gh issue list --label govulncheck --state open --limit 1 --json number --jq '.[].number')" ]; then
+            echo "A govulncheck issue is already open; not filing another."
+            exit 0
+          fi
+          gh label create govulncheck --description "Reported by the scheduled govulncheck run" --color d93f0b --force
+          {
+            echo "The scheduled \`govulncheck\` run reported vulnerabilities that are not in this workflow's accepted list."
+            echo
+            echo "Run: ${RUN_URL}"
+            echo
+            echo '### New'
+            echo '```'
+            cat "${RUNNER_TEMP}/new.txt" 2>/dev/null || echo '(see full output below)'
+            echo '```'
+            echo
+            echo '### Full output'
+            echo '```'
+            cat "${RUNNER_TEMP}/govulncheck.txt"
+            echo '```'
+            echo
+            echo "Standard library findings are usually cleared by bumping the \`go\` directive in \`go.mod\` to the version named under \"Fixed in\"."
+          } > "${RUNNER_TEMP}/issue.md"
+          gh issue create --title "govulncheck: new vulnerabilities reported" --label govulncheck --body-file "${RUNNER_TEMP}/issue.md"

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -26,6 +26,9 @@ jobs:
     env:
       # ./... does not cross module boundaries, so every module is listed.
       MODULES: ". installer integration/testapp"
+      # govulncheck's source mode only analyses the files the current build
+      # configuration selects, so scan each GOOS/GOARCH we actually release.
+      TARGETS: "linux/amd64 linux/arm64 darwin/amd64 darwin/arm64"
       # Findings we have looked at and are choosing to carry, so the run stays
       # quiet until something NEW appears. Everything else fails the job.
       #
@@ -66,20 +69,29 @@ jobs:
           rm -f "${RUNNER_TEMP}"/gv-*.json
           n=0
           scan_error=0
-          for module in ${MODULES}; do
-            n=$((n + 1))
-            echo "===== ${module}" >> "${RUNNER_TEMP}/report.txt"
-            ( cd "${module}" && govulncheck -format json ./... ) > "${RUNNER_TEMP}/gv-${n}.json" 2> "${RUNNER_TEMP}/gv-${n}.err"
-            rc=$?
-            # govulncheck: 0 = clean, 3 = vulnerabilities found, anything else = it failed to run.
-            if [ "${rc}" -ne 0 ] && [ "${rc}" -ne 3 ]; then
-              scan_error=1
-              echo "govulncheck exited ${rc} (scanner error, not a finding):" >> "${RUNNER_TEMP}/report.txt"
-              cat "${RUNNER_TEMP}/gv-${n}.err" >> "${RUNNER_TEMP}/report.txt"
-              rm -f "${RUNNER_TEMP}/gv-${n}.json"
-              continue
-            fi
-            ( cd "${module}" && govulncheck ./... ) >> "${RUNNER_TEMP}/report.txt" 2>&1
+          # Releases are built CGO_ENABLED=0 for each GOOS/GOARCH in TARGETS. govulncheck's
+          # source mode only sees the files the current build configuration selects, so a
+          # single native run would miss a path reachable only on another target.
+          export CGO_ENABLED=0
+          for target in ${TARGETS}; do
+            GOOS="${target%%/*}"
+            GOARCH="${target##*/}"
+            export GOOS GOARCH
+            for module in ${MODULES}; do
+              n=$((n + 1))
+              echo "===== ${target} ${module}" >> "${RUNNER_TEMP}/report.txt"
+              ( cd "${module}" && govulncheck -format json ./... ) > "${RUNNER_TEMP}/gv-${n}.json" 2> "${RUNNER_TEMP}/gv-${n}.err"
+              rc=$?
+              # govulncheck: 0 = clean, 3 = vulnerabilities found, anything else = it failed to run.
+              if [ "${rc}" -ne 0 ] && [ "${rc}" -ne 3 ]; then
+                scan_error=1
+                echo "govulncheck exited ${rc} (scanner error, not a finding):" >> "${RUNNER_TEMP}/report.txt"
+                cat "${RUNNER_TEMP}/gv-${n}.err" >> "${RUNNER_TEMP}/report.txt"
+                rm -f "${RUNNER_TEMP}/gv-${n}.json"
+                continue
+              fi
+              ( cd "${module}" && govulncheck ./... ) >> "${RUNNER_TEMP}/report.txt" 2>&1
+            done
           done
           set -e
 
@@ -91,13 +103,17 @@ jobs:
             exit 1
           fi
 
-          # Fail only on findings govulncheck considers reachable (a symbol-level trace)
-          # that are not in ACCEPTED -- the same set its "Your code is affected by N
-          # vulnerabilities" line counts.
+          # Fail on findings govulncheck considers reachable (a symbol-level trace) that
+          # are not in ACCEPTED -- the same set its "Your code is affected by N
+          # vulnerabilities" line counts -- and on accepted IDs that have since gained a
+          # fix for the module path we actually depend on.
           python3 - "$ACCEPTED" > "${RUNNER_TEMP}/new.txt" <<'PY'
           import glob, json, os, sys
+
           accepted = {x for x in sys.argv[1].split() if x}
-          reachable = set()
+          reachable = {}   # osv id -> set of module paths it was reached through
+          advisories = {}
+
           for path in glob.glob(os.environ["RUNNER_TEMP"] + "/gv-*.json"):
               raw = open(path).read()
               dec, i = json.JSONDecoder(), 0
@@ -105,22 +121,49 @@ jobs:
                   while i < len(raw) and raw[i].isspace(): i += 1
                   if i >= len(raw): break
                   obj, i = dec.raw_decode(raw, i)
+                  if "osv" in obj:
+                      advisories[obj["osv"]["id"]] = obj["osv"]
                   f = obj.get("finding")
-                  if f and (f.get("trace") or [{}])[0].get("function"):
-                      reachable.add(f["osv"])
-          new = sorted(reachable - accepted)
-          if new:
-              print("\n".join(new))
+                  if f:
+                      frame = (f.get("trace") or [{}])[0]
+                      if frame.get("function"):
+                          reachable.setdefault(f["osv"], set()).add(frame.get("module"))
+
+          def fixed_versions(osv_id, modules):
+              # Only a fix on a module path we actually import counts. These advisories
+              # routinely list a renamed module (moby/moby/v2) that carries the fix while
+              # the path we depend on (docker/docker) never gets one.
+              out = []
+              for affected in (advisories.get(osv_id) or {}).get("affected", []):
+                  if affected.get("package", {}).get("name") not in modules:
+                      continue
+                  for rng in affected.get("ranges", []):
+                      for event in rng.get("events", []):
+                          if event.get("fixed"):
+                              out.append(f"{affected['package']['name']}@{event['fixed']}")
+              return out
+
+          problems = []
+          for osv_id in sorted(reachable):
+              if osv_id not in accepted:
+                  problems.append(osv_id)
+                  continue
+              fixes = fixed_versions(osv_id, reachable[osv_id])
+              if fixes:
+                  problems.append(f"{osv_id} (accepted, but now fixed in {', '.join(sorted(set(fixes)))} -- drop it from ACCEPTED and upgrade)")
+
+          if problems:
+              print("\n".join(problems))
           PY
 
           if [ -s "${RUNNER_TEMP}/new.txt" ]; then
             echo "outcome=vulnerable" >> "$GITHUB_OUTPUT"
-            echo "New reachable vulnerabilities:"
+            echo "Actionable findings:"
             cat "${RUNNER_TEMP}/new.txt"
             exit 1
           fi
           echo "outcome=clean" >> "$GITHUB_OUTPUT"
-          echo "No new reachable vulnerabilities (accepted: ${ACCEPTED:-none})."
+          echo "No actionable findings (accepted: ${ACCEPTED:-none})."
 
       - name: Summarize
         if: always()
@@ -142,12 +185,22 @@ jobs:
           GH_REPO: ${{ github.repository }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           OUTCOME: ${{ steps.scan.outputs.outcome }}
+          SCANNED_REF: ${{ github.ref_name }}
+          SCANNED_SHA: ${{ github.sha }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
         run: |
           # Always reflect THIS run into the tracking issue. An issue opened for an
           # earlier advisory says nothing about a new one, so bailing out when any issue
           # is open would recreate the silence this workflow exists to end. One issue,
           # kept current, with each run appended.
-          title="govulncheck: findings on the default branch"
+          # A workflow_dispatch can target any ref, so never describe a run as being the
+          # default branch without checking. Non-default refs get their own issue rather
+          # than appending a branch-only finding to the canonical one.
+          if [ "${SCANNED_REF}" = "${DEFAULT_BRANCH}" ]; then
+            title="govulncheck: findings on ${DEFAULT_BRANCH}"
+          else
+            title="govulncheck: findings on ${SCANNED_REF}"
+          fi
           if [ -s "${RUNNER_TEMP}/report.txt" ]; then
             body_output=$(cat "${RUNNER_TEMP}/report.txt")
           else
@@ -165,6 +218,8 @@ jobs:
           {
             echo "${headline}"
             echo
+            echo "Ref: \`${SCANNED_REF}\` @ \`${SCANNED_SHA}\`"
+            echo "Targets: \`${TARGETS}\`"
             echo "Run: ${RUN_URL}"
             if [ -s "${RUNNER_TEMP}/new.txt" ]; then
               echo
@@ -183,11 +238,14 @@ jobs:
             echo '</details>'
             echo
             echo "Standard library findings are usually cleared by bumping the \`go\` directive in \`go.mod\` (and any \`FROM golang:\` base image) to the version named under \"Fixed in\"."
+            echo
+            echo "An entry marked \"accepted, but now fixed\" means an ID in this workflow's ACCEPTED list has gained a fix for a module path we import: upgrade and drop the ID, rather than re-accepting it."
           } > "${RUNNER_TEMP}/body.md"
 
           # Let a failure of the lookup itself stop the job rather than read as "no issue
           # open", which would file a duplicate.
-          existing=$(gh issue list --label govulncheck --state open --limit 1 --json number --jq '.[].number')
+          existing=$(gh issue list --label govulncheck --state open --limit 30 --json number,title \
+            --jq "[.[] | select(.title == \"${title}\")] | .[0].number // empty")
 
           if [ -n "${existing}" ]; then
             gh issue comment "${existing}" --body-file "${RUNNER_TEMP}/body.md"

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -25,11 +25,13 @@ jobs:
       contents: read
       issues: write
     env:
-      # ./... does not cross module boundaries, so every module is listed.
-      MODULES: ". installer integration/testapp"
-      # govulncheck's source mode only analyses the files the current build
-      # configuration selects, so scan each GOOS/GOARCH we actually release.
-      TARGETS: "linux/amd64 linux/arm64 darwin/amd64 darwin/arm64"
+      # One line per module: the module directory, then the GOOS/GOARCH targets
+      # that module actually ships on. ./... does not cross module boundaries,
+      # so every shipped module is listed; the targets differ per module because
+      # what each one ships on differs.
+      SCAN_MATRIX: |
+        . linux/amd64 linux/arm64 darwin/amd64 darwin/arm64
+        installer linux/amd64 linux/arm64
       # Findings we have looked at and are choosing to carry, so the run stays
       # quiet until something NEW appears. Everything else fails the job.
       #
@@ -81,16 +83,33 @@ jobs:
           rm -f "${RUNNER_TEMP}"/gv-*.json
           n=0
           scan_error=0
-          # Releases are built CGO_ENABLED=0 for each GOOS/GOARCH in TARGETS. govulncheck's
-          # source mode only sees the files the current build configuration selects, so a
-          # single native run would miss a path reachable only on another target.
+          toolchain=$(go env GOVERSION)
+
+          # Releases are built CGO_ENABLED=0, and govulncheck's source mode only sees the
+          # files the current build configuration selects -- so each module is scanned for
+          # the platforms that module actually ships on. They are not the same list: a
+          # container-only artifact never runs on darwin, and reporting a darwin-only path
+          # against it would be a finding nobody can act on.
           export CGO_ENABLED=0
-          for target in ${TARGETS}; do
-            GOOS="${target%%/*}"
-            GOARCH="${target##*/}"
-            export GOOS GOARCH
-            for module in ${MODULES}; do
+          while read -r module targets; do
+            [ -z "${module}" ] && continue
+
+            # One setup-go installs one toolchain, from the root go.mod. If a nested
+            # module asks for a different one, this would silently scan it against the
+            # wrong standard library -- so say so rather than report a wrong answer.
+            want=$(awk '/^go /{print "go" $2; exit}' "${module}/go.mod")
+            if [ "${want}" != "${toolchain}" ]; then
+              scan_error=1
+              echo "===== ${module}" >> "${RUNNER_TEMP}/report.txt"
+              echo "module declares ${want} but the scan is running ${toolchain}; align the go directives or give this module its own scan job." >> "${RUNNER_TEMP}/report.txt"
+              continue
+            fi
+
+            for target in ${targets}; do
               n=$((n + 1))
+              GOOS="${target%%/*}"
+              GOARCH="${target##*/}"
+              export GOOS GOARCH
               echo "===== ${target} ${module}" >> "${RUNNER_TEMP}/report.txt"
               ( cd "${module}" && govulncheck -format json ./... ) > "${RUNNER_TEMP}/gv-${n}.json" 2> "${RUNNER_TEMP}/gv-${n}.err"
               rc=$?
@@ -104,7 +123,9 @@ jobs:
               fi
               ( cd "${module}" && govulncheck ./... ) >> "${RUNNER_TEMP}/report.txt" 2>&1
             done
-          done
+          done <<EOF
+          ${SCAN_MATRIX}
+          EOF
           set -e
 
           cat "${RUNNER_TEMP}/report.txt"
@@ -204,14 +225,6 @@ jobs:
                           # A trailing introduced with no fixed is an open, unfixed interval.
               return out
 
-          # An accepted ID that no longer shows up is a suppression with nothing left to
-          # suppress -- dead config that would silently swallow the advisory if a future
-          # version reintroduced it. Worth saying, not worth failing a clean run over.
-          stale = sorted(accepted - set(reachable))
-          if stale:
-              with open(os.environ["RUNNER_TEMP"] + "/stale-accepted.txt", "w") as handle:
-                  handle.write("\n".join(stale) + "\n")
-
           problems = []
           for osv_id in sorted(reachable):
               if osv_id not in accepted:
@@ -253,18 +266,6 @@ jobs:
           {
             echo '## govulncheck'
             echo
-            if [ -s "${RUNNER_TEMP}/stale-accepted.txt" ]; then
-              echo '### Accepted IDs no longer reported'
-              echo
-              echo 'These are in ACCEPTED but the scan no longer finds them -- most likely'
-              echo 'the dependency was upgraded. Drop them, so the list cannot silently'
-              echo 'swallow the advisory if a later version reintroduces it.'
-              echo
-              echo '```'
-              cat "${RUNNER_TEMP}/stale-accepted.txt"
-              echo '```'
-              echo
-            fi
             echo '```'
             cat "${RUNNER_TEMP}/report.txt" 2>/dev/null || echo '(no output -- the job failed before scanning)'
             echo '```'
@@ -279,7 +280,6 @@ jobs:
           GH_REPO: ${{ github.repository }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           OUTCOME: ${{ steps.scan.outputs.outcome }}
-          TARGETS: "linux/amd64 linux/arm64 darwin/amd64 darwin/arm64"
           SCANNED_SHA: ${{ steps.commit.outputs.sha }}
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
           GITHUB_REF: ${{ github.ref }}
@@ -306,7 +306,7 @@ jobs:
           # tracking state is stale in the other direction.
           if [ "${OUTCOME}" = "clean" ]; then
             if [ -n "${existing}" ]; then
-              gh issue comment "${existing}" --body "The scheduled \`govulncheck\` run is clean again at \`${SCANNED_SHA}\` (targets \`${TARGETS}\`).
+              gh issue comment "${existing}" --body "The scheduled \`govulncheck\` run is clean again at \`${SCANNED_SHA}\`.
 
           Run: ${RUN_URL}
 
@@ -349,7 +349,6 @@ jobs:
             echo "${headline}"
             echo
             echo "Commit: \`${SCANNED_SHA}\`"
-            echo "Targets: \`${TARGETS}\`"
             echo "Run: ${RUN_URL}"
             if [ -s "${RUNNER_TEMP}/new.txt" ]; then
               echo

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -10,6 +10,12 @@ on:
 
 permissions: {}
 
+# The reporting step reads then writes the tracking issue, which is not atomic.
+# A manual dispatch overlapping the scheduled run could otherwise file two.
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
 jobs:
   govulncheck:
     name: Govulncheck
@@ -18,6 +24,8 @@ jobs:
       contents: read
       issues: write
     env:
+      # ./... does not cross module boundaries, so every module is listed.
+      MODULES: ". installer integration/testapp"
       # Findings we have looked at and are choosing to carry, so the run stays
       # quiet until something NEW appears. Everything else fails the job.
       #
@@ -29,11 +37,14 @@ jobs:
       # module-path migration onto a beta.
       #
       # govulncheck reports these as reachable across most of the docker client
-      # surface we use, so treat that as "we link the module", not as a specific
+      # surface, so treat that as "we link the module", not as a specific
       # exploitable path: both bugs are in the *daemon's* plugin authorization,
       # and we are a client of the daemon, not a host of it.
       #
-      # Revisit when moby/moby/v2 is stable.
+      # An ID stays accepted only while it has no fix. Re-check when bumping
+      # docker, and drop the ID once a fixed version is reachable for us --
+      # otherwise this list keeps the job green exactly when it could go green
+      # honestly. Revisit when moby/moby/v2 is stable.
       ACCEPTED: "GO-2026-4887 GO-2026-4883"
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -50,34 +61,65 @@ jobs:
       - name: Run govulncheck
         id: scan
         run: |
-          govulncheck -format json ./... > "${RUNNER_TEMP}/govulncheck.json"
-          govulncheck ./... > "${RUNNER_TEMP}/govulncheck.txt" 2>&1 || true
-          cat "${RUNNER_TEMP}/govulncheck.txt"
+          set +e
+          : > "${RUNNER_TEMP}/report.txt"
+          rm -f "${RUNNER_TEMP}"/gv-*.json
+          n=0
+          scan_error=0
+          for module in ${MODULES}; do
+            n=$((n + 1))
+            echo "===== ${module}" >> "${RUNNER_TEMP}/report.txt"
+            ( cd "${module}" && govulncheck -format json ./... ) > "${RUNNER_TEMP}/gv-${n}.json" 2> "${RUNNER_TEMP}/gv-${n}.err"
+            rc=$?
+            # govulncheck: 0 = clean, 3 = vulnerabilities found, anything else = it failed to run.
+            if [ "${rc}" -ne 0 ] && [ "${rc}" -ne 3 ]; then
+              scan_error=1
+              echo "govulncheck exited ${rc} (scanner error, not a finding):" >> "${RUNNER_TEMP}/report.txt"
+              cat "${RUNNER_TEMP}/gv-${n}.err" >> "${RUNNER_TEMP}/report.txt"
+              rm -f "${RUNNER_TEMP}/gv-${n}.json"
+              continue
+            fi
+            ( cd "${module}" && govulncheck ./... ) >> "${RUNNER_TEMP}/report.txt" 2>&1
+          done
+          set -e
 
-          # Fail only on findings govulncheck considers reachable (a symbol-level
-          # trace) that are not in ACCEPTED. This is the same set its own
-          # "Your code is affected by N vulnerabilities" line counts.
-          new=$(python3 - "$ACCEPTED" <<'PY'
-          import json, os, sys
-          accepted = {x for x in sys.argv[1].split() if x}
-          raw = open(os.environ["RUNNER_TEMP"] + "/govulncheck.json").read()
-          dec, i, reachable = json.JSONDecoder(), 0, set()
-          while i < len(raw):
-              while i < len(raw) and raw[i].isspace(): i += 1
-              if i >= len(raw): break
-              obj, i = dec.raw_decode(raw, i)
-              f = obj.get("finding")
-              if f and (f.get("trace") or [{}])[0].get("function"):
-                  reachable.add(f["osv"])
-          print("\n".join(sorted(reachable - accepted)))
-          PY
-          )
-          if [ -n "$new" ]; then
-            echo "New reachable vulnerabilities:"
-            echo "$new"
-            echo "$new" > "${RUNNER_TEMP}/new.txt"
+          cat "${RUNNER_TEMP}/report.txt"
+
+          if [ "${scan_error}" -eq 1 ]; then
+            echo "outcome=error" >> "$GITHUB_OUTPUT"
+            echo "govulncheck failed to run; see above." >&2
             exit 1
           fi
+
+          # Fail only on findings govulncheck considers reachable (a symbol-level trace)
+          # that are not in ACCEPTED -- the same set its "Your code is affected by N
+          # vulnerabilities" line counts.
+          python3 - "$ACCEPTED" > "${RUNNER_TEMP}/new.txt" <<'PY'
+          import glob, json, os, sys
+          accepted = {x for x in sys.argv[1].split() if x}
+          reachable = set()
+          for path in glob.glob(os.environ["RUNNER_TEMP"] + "/gv-*.json"):
+              raw = open(path).read()
+              dec, i = json.JSONDecoder(), 0
+              while i < len(raw):
+                  while i < len(raw) and raw[i].isspace(): i += 1
+                  if i >= len(raw): break
+                  obj, i = dec.raw_decode(raw, i)
+                  f = obj.get("finding")
+                  if f and (f.get("trace") or [{}])[0].get("function"):
+                      reachable.add(f["osv"])
+          new = sorted(reachable - accepted)
+          if new:
+              print("\n".join(new))
+          PY
+
+          if [ -s "${RUNNER_TEMP}/new.txt" ]; then
+            echo "outcome=vulnerable" >> "$GITHUB_OUTPUT"
+            echo "New reachable vulnerabilities:"
+            cat "${RUNNER_TEMP}/new.txt"
+            exit 1
+          fi
+          echo "outcome=clean" >> "$GITHUB_OUTPUT"
           echo "No new reachable vulnerabilities (accepted: ${ACCEPTED:-none})."
 
       - name: Summarize
@@ -87,40 +129,70 @@ jobs:
             echo '## govulncheck'
             echo
             echo '```'
-            cat "${RUNNER_TEMP}/govulncheck.txt"
+            cat "${RUNNER_TEMP}/report.txt" 2>/dev/null || echo '(no output -- the job failed before scanning)'
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
 
-      # A scheduled job that only goes red in the Actions tab is the same silence
-      # this workflow exists to end, so failures open an issue. One at a time:
-      # if a govulncheck issue is already open, the finding is already visible.
+      # Reports any failure, not just a failing scan: a broken checkout or a
+      # failed govulncheck install is also something nobody would otherwise see.
       - name: Report
-        if: failure() && steps.scan.outcome == 'failure'
+        if: failure()
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          OUTCOME: ${{ steps.scan.outputs.outcome }}
         run: |
-          if [ -n "$(gh issue list --label govulncheck --state open --limit 1 --json number --jq '.[].number')" ]; then
-            echo "A govulncheck issue is already open; not filing another."
-            exit 0
+          # Always reflect THIS run into the tracking issue. An issue opened for an
+          # earlier advisory says nothing about a new one, so bailing out when any issue
+          # is open would recreate the silence this workflow exists to end. One issue,
+          # kept current, with each run appended.
+          title="govulncheck: findings on the default branch"
+          if [ -s "${RUNNER_TEMP}/report.txt" ]; then
+            body_output=$(cat "${RUNNER_TEMP}/report.txt")
+          else
+            body_output="(govulncheck produced no output -- the job failed before or during the scan; see the run log.)"
           fi
-          gh label create govulncheck --description "Reported by the scheduled govulncheck run" --color d93f0b --force
+
+          if [ "${OUTCOME}" = "error" ]; then
+            headline="The scheduled \`govulncheck\` run **could not complete**. This is a scanner or environment failure, not a vulnerability report."
+          elif [ "${OUTCOME}" = "vulnerable" ]; then
+            headline="The scheduled \`govulncheck\` run found vulnerabilities that are not in this workflow's accepted list."
+          else
+            headline="The scheduled \`govulncheck\` job failed before it could scan. This is an environment or setup failure, not a vulnerability report."
+          fi
+
           {
-            echo "The scheduled \`govulncheck\` run reported vulnerabilities that are not in this workflow's accepted list."
+            echo "${headline}"
             echo
             echo "Run: ${RUN_URL}"
+            if [ -s "${RUNNER_TEMP}/new.txt" ]; then
+              echo
+              echo '### Not in the accepted list'
+              echo '```'
+              cat "${RUNNER_TEMP}/new.txt"
+              echo '```'
+            fi
             echo
-            echo '### New'
+            echo '<details><summary>govulncheck output</summary>'
+            echo
             echo '```'
-            cat "${RUNNER_TEMP}/new.txt" 2>/dev/null || echo '(see full output below)'
+            echo "${body_output}"
             echo '```'
             echo
-            echo '### Full output'
-            echo '```'
-            cat "${RUNNER_TEMP}/govulncheck.txt"
-            echo '```'
+            echo '</details>'
             echo
-            echo "Standard library findings are usually cleared by bumping the \`go\` directive in \`go.mod\` to the version named under \"Fixed in\"."
-          } > "${RUNNER_TEMP}/issue.md"
-          gh issue create --title "govulncheck: new vulnerabilities reported" --label govulncheck --body-file "${RUNNER_TEMP}/issue.md"
+            echo "Standard library findings are usually cleared by bumping the \`go\` directive in \`go.mod\` (and any \`FROM golang:\` base image) to the version named under \"Fixed in\"."
+          } > "${RUNNER_TEMP}/body.md"
+
+          # Let a failure of the lookup itself stop the job rather than read as "no issue
+          # open", which would file a duplicate.
+          existing=$(gh issue list --label govulncheck --state open --limit 1 --json number --jq '.[].number')
+
+          if [ -n "${existing}" ]; then
+            gh issue comment "${existing}" --body-file "${RUNNER_TEMP}/body.md"
+            echo "Updated issue #${existing}."
+          else
+            gh label create govulncheck --description "Reported by the scheduled govulncheck run" --color d93f0b --force
+            gh issue create --title "${title}" --label govulncheck --body-file "${RUNNER_TEMP}/body.md"
+          fi

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -128,17 +128,36 @@ jobs:
                           mods.setdefault(frame.get("module"), set()).add(frame.get("version") or "v0.0.0")
 
           def parse(version):
-              # Enough of semver to order Go module versions: drop the leading v and any
-              # +incompatible/build metadata, split off a prerelease, compare numerically.
-              version = version.lstrip("v").split("+", 1)[0]
+              # Order Go module versions by SemVer rules. Two prefixes to shed: module
+              # versions carry "v" (v28.5.2), and stdlib findings carry "go" (go1.26.5)
+              # while the advisory's own ranges use a bare 1.26.5 -- comparing those
+              # unnormalized would match the wrong interval entirely. Build metadata
+              # (+incompatible) does not participate in precedence.
+              version = version.split("+", 1)[0]
+              if version.startswith("go"):
+                  version = version[2:]
+              elif version.startswith("v"):
+                  version = version[1:]
               main, _, pre = version.partition("-")
-              parts = []
+
+              release = []
               for chunk in main.split("."):
-                  parts.append(int(chunk) if chunk.isdigit() else 0)
-              while len(parts) < 3:
-                  parts.append(0)
-              # No prerelease sorts above a prerelease of the same version.
-              return (parts, 0 if pre else 1, pre)
+                  release.append(int(chunk) if chunk.isdigit() else 0)
+              while len(release) < 3:
+                  release.append(0)
+
+              # SemVer 11.4: dot-separated prerelease identifiers compare field by field;
+              # numeric ones compare numerically and rank below alphanumeric ones. String
+              # comparison would put beta.10 before beta.2.
+              identifiers = []
+              for chunk in pre.split(".") if pre else []:
+                  if chunk.isdigit():
+                      identifiers.append((0, int(chunk), ""))
+                  else:
+                      identifiers.append((1, 0, chunk))
+
+              # A version with no prerelease outranks the same release with one.
+              return (release, 0 if pre else 1, identifiers)
 
           def fix_for(osv_id, module_versions):
               # Only a fix on a module path we actually import counts: these advisories
@@ -172,6 +191,14 @@ jobs:
                                   introduced = None
                           # A trailing introduced with no fixed is an open, unfixed interval.
               return out
+
+          # An accepted ID that no longer shows up is a suppression with nothing left to
+          # suppress -- dead config that would silently swallow the advisory if a future
+          # version reintroduced it. Worth saying, not worth failing a clean run over.
+          stale = sorted(accepted - set(reachable))
+          if stale:
+              with open(os.environ["RUNNER_TEMP"] + "/stale-accepted.txt", "w") as handle:
+                  handle.write("\n".join(stale) + "\n")
 
           problems = []
           for osv_id in sorted(reachable):
@@ -214,6 +241,18 @@ jobs:
           {
             echo '## govulncheck'
             echo
+            if [ -s "${RUNNER_TEMP}/stale-accepted.txt" ]; then
+              echo '### Accepted IDs no longer reported'
+              echo
+              echo 'These are in ACCEPTED but the scan no longer finds them -- most likely'
+              echo 'the dependency was upgraded. Drop them, so the list cannot silently'
+              echo 'swallow the advisory if a later version reintroduces it.'
+              echo
+              echo '```'
+              cat "${RUNNER_TEMP}/stale-accepted.txt"
+              echo '```'
+              echo
+            fi
             echo '```'
             cat "${RUNNER_TEMP}/report.txt" 2>/dev/null || echo '(no output -- the job failed before scanning)'
             echo '```'
@@ -294,7 +333,11 @@ jobs:
           # $ENV.TITLE is expanded by jq, not by the shell -- that is the point of passing
           # the title as data instead of interpolating it, so SC2016 is expected here.
           # shellcheck disable=SC2016
-          existing=$(TITLE="${title}" gh issue list --label govulncheck --state open --limit 30 --json number,title \
+          # --limit bounds how many issues are fetched, and the jq filter only sees those.
+          # Failed dispatches on different refs deliberately open separate issues, so a
+          # small page could miss this ref's issue and open a duplicate. The label already
+          # narrows this to our own issues; the limit is just a sane ceiling above it.
+          existing=$(TITLE="${title}" gh issue list --label govulncheck --state open --limit 1000 --json number,title \
             --jq '[.[] | select(.title == $ENV.TITLE)] | .[0].number // empty')
 
           if [ -n "${existing}" ]; then

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -111,7 +111,7 @@ jobs:
           import glob, json, os, sys
 
           accepted = {x for x in sys.argv[1].split() if x}
-          reachable = {}   # osv id -> set of module paths it was reached through
+          reachable = {}   # osv id -> {module path: set of versions} it was reached through
           advisories = {}
 
           for path in glob.glob(os.environ["RUNNER_TEMP"] + "/gv-*.json"):
@@ -127,20 +127,53 @@ jobs:
                   if f:
                       frame = (f.get("trace") or [{}])[0]
                       if frame.get("function"):
-                          reachable.setdefault(f["osv"], set()).add(frame.get("module"))
+                          mods = reachable.setdefault(f["osv"], {})
+                          mods.setdefault(frame.get("module"), set()).add(frame.get("version") or "v0.0.0")
 
-          def fixed_versions(osv_id, modules):
-              # Only a fix on a module path we actually import counts. These advisories
-              # routinely list a renamed module (moby/moby/v2) that carries the fix while
-              # the path we depend on (docker/docker) never gets one.
+          def parse(version):
+              # Enough of semver to order Go module versions: drop the leading v and any
+              # +incompatible/build metadata, split off a prerelease, compare numerically.
+              version = version.lstrip("v").split("+", 1)[0]
+              main, _, pre = version.partition("-")
+              parts = []
+              for chunk in main.split("."):
+                  parts.append(int(chunk) if chunk.isdigit() else 0)
+              while len(parts) < 3:
+                  parts.append(0)
+              # No prerelease sorts above a prerelease of the same version.
+              return (parts, 0 if pre else 1, pre)
+
+          def fix_for(osv_id, module_versions):
+              # Only a fix on a module path we actually import counts: these advisories
+              # routinely list a renamed module (moby/moby/v2) carrying the fix while the
+              # path we depend on (docker/docker) never gets one.
+              #
+              # And only a fix for the interval OUR version falls in counts. An advisory
+              # can be fixed, then reintroduced and left unfixed; treating the historical
+              # fixed event as an upgrade would fail the job forever with advice that does
+              # not apply.
               out = []
               for affected in (advisories.get(osv_id) or {}).get("affected", []):
-                  if affected.get("package", {}).get("name") not in modules:
+                  name = affected.get("package", {}).get("name")
+                  if name not in module_versions:
                       continue
-                  for rng in affected.get("ranges", []):
-                      for event in rng.get("events", []):
-                          if event.get("fixed"):
-                              out.append(f"{affected['package']['name']}@{event['fixed']}")
+                  for ours in module_versions[name]:
+                      try:
+                          target = parse(ours)
+                      except Exception:
+                          continue
+                      for rng in affected.get("ranges", []):
+                          introduced, fixed = None, None
+                          for event in rng.get("events", []):
+                              if event.get("introduced") is not None:
+                                  # A new interval starts; the previous one did not contain us.
+                                  introduced, fixed = event["introduced"], None
+                              elif event.get("fixed") is not None:
+                                  fixed = event["fixed"]
+                                  if introduced is not None and parse(introduced) <= target < parse(fixed):
+                                      out.append(f"{name}@{fixed}")
+                                  introduced = None
+                          # A trailing introduced with no fixed is an open, unfixed interval.
               return out
 
           problems = []
@@ -148,7 +181,7 @@ jobs:
               if osv_id not in accepted:
                   problems.append(osv_id)
                   continue
-              fixes = fixed_versions(osv_id, reachable[osv_id])
+              fixes = fix_for(osv_id, reachable[osv_id])
               if fixes:
                   problems.append(f"{osv_id} (accepted, but now fixed in {', '.join(sorted(set(fixes)))} -- drop it from ACCEPTED and upgrade)")
 
@@ -244,8 +277,13 @@ jobs:
 
           # Let a failure of the lookup itself stop the job rather than read as "no issue
           # open", which would file a duplicate.
-          existing=$(gh issue list --label govulncheck --state open --limit 30 --json number,title \
-            --jq "[.[] | select(.title == \"${title}\")] | .[0].number // empty")
+          # The title carries a ref name, which git allows to contain quotes -- pass it to
+          # jq as data via $ENV rather than interpolating it into the jq program.
+          # $ENV.TITLE is expanded by jq, not by the shell -- that is the point of passing
+          # the title as data instead of interpolating it, so SC2016 is expected here.
+          # shellcheck disable=SC2016
+          existing=$(TITLE="${title}" gh issue list --label govulncheck --state open --limit 30 --json number,title \
+            --jq '[.[] | select(.title == $ENV.TITLE)] | .[0].number // empty')
 
           if [ -n "${existing}" ]; then
             gh issue comment "${existing}" --body-file "${RUNNER_TEMP}/body.md"

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -51,9 +51,12 @@ jobs:
       # honestly. Revisit when moby/moby/v2 is stable.
       ACCEPTED: "GO-2026-4887 GO-2026-4883"
     steps:
-      # Always scan the default branch, including on workflow_dispatch. What we
-      # ship is what needs scanning, and pinning it here is what keeps this a
-      # single tracking issue rather than one per dispatched ref.
+      # Always scan the default branch, including on workflow_dispatch: what we
+      # ship is what needs scanning, and pinning it keeps this to one tracking
+      # issue rather than one per dispatched ref. Note this pins the source tree
+      # only -- GitHub loads the workflow definition itself from the dispatched
+      # ref, which is why the reporting step checks it is the canonical run
+      # before touching the issue.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.repository.default_branch }}
@@ -279,18 +282,24 @@ jobs:
           TARGETS: "linux/amd64 linux/arm64 darwin/amd64 darwin/arm64"
           SCANNED_SHA: ${{ steps.commit.outputs.sha }}
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          GITHUB_REF: ${{ github.ref }}
         run: |
-          # One tracking issue per repo. The scan always runs against the default branch,
-          # so there is exactly one thing to track and the title is fixed.
-          title="govulncheck: findings on ${DEFAULT_BRANCH}"
+          # The scan always runs against the default branch, so there is exactly one thing
+          # to track: one issue, found by its own label. Matching on the title instead
+          # would break the moment the default branch is renamed or someone edits the
+          # title, and would silently open a second issue.
+          existing=$(gh issue list --label govulncheck --state open --limit 1 --json number --jq '.[0].number // empty')
 
-          # shellcheck disable=SC2016
-          lookup() {
-            TITLE="${title}" gh issue list --label govulncheck --state open --limit 1000 --json number,title \
-              --jq '[.[] | select(.title == $ENV.TITLE)] | .[0].number // empty'
-          }
-
-          existing=$(lookup)
+          # Only the canonical run owns that issue. workflow_dispatch pins the *source
+          # tree* to the default branch but not the workflow definition, which GitHub
+          # loads from the dispatched ref -- so a branch carrying an experimental ACCEPTED
+          # list or reporting change would otherwise write to, or close, the real issue.
+          # Dispatching from a branch stays useful for trying this workflow out; it just
+          # reports to the run summary instead.
+          if [ "${GITHUB_REF}" != "refs/heads/${DEFAULT_BRANCH}" ]; then
+            echo "Running from ${GITHUB_REF}, not the default branch -- results are in the run summary; the tracking issue is left alone."
+            exit 0
+          fi
 
           # A clean run has to close the loop too. Otherwise the issue from a run that
           # failed -- or from a vulnerability since fixed -- stays open forever, and the
@@ -368,5 +377,5 @@ jobs:
             echo "Updated issue #${existing}."
           else
             gh label create govulncheck --description "Reported by the scheduled govulncheck run" --color d93f0b --force
-            gh issue create --title "${title}" --label govulncheck --body-file "${RUNNER_TEMP}/body.md"
+            gh issue create --title "govulncheck: findings on the default branch" --label govulncheck --body-file "${RUNNER_TEMP}/body.md"
           fi

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -258,19 +258,30 @@ jobs:
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
 
-      # Reports any failure, not just a failing scan: a broken checkout or a
-      # failed govulncheck install is also something nobody would otherwise see.
+      # Runs on success too, not just failure: a failing run leaves an issue open,
+      # and only a later clean run can close it. Skipped only on cancellation.
       - name: Report
-        if: failure()
+        if: ${{ !cancelled() }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           OUTCOME: ${{ steps.scan.outputs.outcome }}
+          TARGETS: "linux/amd64 linux/arm64 darwin/amd64 darwin/arm64"
           SCANNED_REF: ${{ github.ref_name }}
           SCANNED_SHA: ${{ github.sha }}
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
         run: |
+          # --limit bounds how many issues are fetched, and the jq filter only sees those.
+          # Failed dispatches on different refs deliberately open separate issues, so a
+          # small page could miss this ref's issue and open a duplicate. The label already
+          # narrows this to our own issues; the limit is just a sane ceiling above it.
+          lookup() {
+            # shellcheck disable=SC2016
+            TITLE="$1" gh issue list --label govulncheck --state open --limit 1000 --json number,title \
+              --jq '[.[] | select(.title == $ENV.TITLE)] | .[0].number // empty'
+          }
+
           # Always reflect THIS run into the tracking issue. An issue opened for an
           # earlier advisory says nothing about a new one, so bailing out when any issue
           # is open would recreate the silence this workflow exists to end. One issue,
@@ -283,6 +294,26 @@ jobs:
           else
             title="govulncheck: findings on ${SCANNED_REF}"
           fi
+          existing=$(lookup "${title}")
+
+          # A clean run has to close the loop as well. Otherwise the issue from a run that
+          # failed -- or from a vulnerability since fixed -- stays open forever and the
+          # tracking state is stale in the other direction.
+          if [ "${OUTCOME}" = "clean" ]; then
+            if [ -n "${existing}" ]; then
+              gh issue comment "${existing}" --body "The scheduled \`govulncheck\` run is clean again on \`${SCANNED_REF}\` @ \`${SCANNED_SHA}\` (targets \`${TARGETS}\`).
+
+          Run: ${RUN_URL}
+
+          Closing; a later failure reopens tracking by filing a fresh issue."
+              gh issue close "${existing}" --reason completed
+              echo "Closed issue #${existing} -- scan is clean."
+            else
+              echo "Scan is clean and no tracking issue is open; nothing to do."
+            fi
+            exit 0
+          fi
+
           if [ -s "${RUNNER_TEMP}/report.txt" ]; then
             body_output=$(cat "${RUNNER_TEMP}/report.txt")
           else
@@ -333,13 +364,6 @@ jobs:
           # $ENV.TITLE is expanded by jq, not by the shell -- that is the point of passing
           # the title as data instead of interpolating it, so SC2016 is expected here.
           # shellcheck disable=SC2016
-          # --limit bounds how many issues are fetched, and the jq filter only sees those.
-          # Failed dispatches on different refs deliberately open separate issues, so a
-          # small page could miss this ref's issue and open a duplicate. The label already
-          # narrows this to our own issues; the limit is just a sane ceiling above it.
-          existing=$(TITLE="${title}" gh issue list --label govulncheck --state open --limit 1000 --json number,title \
-            --jq '[.[] | select(.title == $ENV.TITLE)] | .[0].number // empty')
-
           if [ -n "${existing}" ]; then
             gh issue comment "${existing}" --body-file "${RUNNER_TEMP}/body.md"
             echo "Updated issue #${existing}."

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -10,12 +10,11 @@ on:
 
 permissions: {}
 
-# The reporting step reads then writes the tracking issue, which is not atomic.
-# Keyed by ref because that is the unit of contention: each ref has its own
-# tracking issue, so runs on different refs never touch the same one, and only
-# same-ref runs -- which scan the same tree -- need to queue behind each other.
+# The reporting step reads then writes the one tracking issue, which is not
+# atomic, so runs must not overlap. Every run scans the same tree, so a queued
+# run that gets superseded was redundant anyway.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}
   cancel-in-progress: false
 
 jobs:
@@ -52,9 +51,17 @@ jobs:
       # honestly. Revisit when moby/moby/v2 is stable.
       ACCEPTED: "GO-2026-4887 GO-2026-4883"
     steps:
+      # Always scan the default branch, including on workflow_dispatch. What we
+      # ship is what needs scanning, and pinning it here is what keeps this a
+      # single tracking issue rather than one per dispatched ref.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          ref: ${{ github.event.repository.default_branch }}
           persist-credentials: false
+
+      - name: Record the scanned commit
+        id: commit
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
@@ -270,51 +277,31 @@ jobs:
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           OUTCOME: ${{ steps.scan.outputs.outcome }}
           TARGETS: "linux/amd64 linux/arm64 darwin/amd64 darwin/arm64"
-          SCANNED_REF: ${{ github.ref_name }}
-          # A branch and a tag can share a short name; the full ref keeps their
-          # tracking issues apart.
-          SCANNED_FULL_REF: ${{ github.ref }}
-          SCANNED_SHA: ${{ github.sha }}
+          SCANNED_SHA: ${{ steps.commit.outputs.sha }}
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
         run: |
-          # --limit bounds how many issues are fetched, and the jq filter only sees those.
-          # Failed dispatches on different refs deliberately open separate issues, so a
-          # small page could miss this ref's issue and open a duplicate. The label already
-          # narrows this to our own issues; the limit is just a sane ceiling above it.
+          # One tracking issue per repo. The scan always runs against the default branch,
+          # so there is exactly one thing to track and the title is fixed.
+          title="govulncheck: findings on ${DEFAULT_BRANCH}"
+
+          # shellcheck disable=SC2016
           lookup() {
-            # shellcheck disable=SC2016
-            TITLE="$1" gh issue list --label govulncheck --state open --limit 1000 --json number,title \
+            TITLE="${title}" gh issue list --label govulncheck --state open --limit 1000 --json number,title \
               --jq '[.[] | select(.title == $ENV.TITLE)] | .[0].number // empty'
           }
 
-          # Always reflect THIS run into the tracking issue. An issue opened for an
-          # earlier advisory says nothing about a new one, so bailing out when any issue
-          # is open would recreate the silence this workflow exists to end. One issue,
-          # kept current, with each run appended.
-          # A workflow_dispatch can target any ref, so never describe a run as being the
-          # default branch without checking. Non-default refs get their own issue rather
-          # than appending a branch-only finding to the canonical one.
-          case "${SCANNED_FULL_REF}" in
-            refs/tags/*) ref_label="tag ${SCANNED_REF}" ;;
-            *)           ref_label="${SCANNED_REF}" ;;
-          esac
-          if [ "${SCANNED_FULL_REF}" = "refs/heads/${DEFAULT_BRANCH}" ]; then
-            title="govulncheck: findings on ${DEFAULT_BRANCH}"
-          else
-            title="govulncheck: findings on ${ref_label}"
-          fi
-          existing=$(lookup "${title}")
+          existing=$(lookup)
 
-          # A clean run has to close the loop as well. Otherwise the issue from a run that
-          # failed -- or from a vulnerability since fixed -- stays open forever and the
+          # A clean run has to close the loop too. Otherwise the issue from a run that
+          # failed -- or from a vulnerability since fixed -- stays open forever, and the
           # tracking state is stale in the other direction.
           if [ "${OUTCOME}" = "clean" ]; then
             if [ -n "${existing}" ]; then
-              gh issue comment "${existing}" --body "The scheduled \`govulncheck\` run is clean again on \`${SCANNED_FULL_REF}\` @ \`${SCANNED_SHA}\` (targets \`${TARGETS}\`).
+              gh issue comment "${existing}" --body "The scheduled \`govulncheck\` run is clean again at \`${SCANNED_SHA}\` (targets \`${TARGETS}\`).
 
           Run: ${RUN_URL}
 
-          Closing; a later failure reopens tracking by filing a fresh issue."
+          Closing; a later failure files a fresh issue."
               gh issue close "${existing}" --reason completed
               echo "Closed issue #${existing} -- scan is clean."
             else
@@ -324,13 +311,12 @@ jobs:
           fi
 
           # GitHub caps an issue body or comment at 65536 characters. A dozen scans of
-          # verbose output can pass that, and gh would fail the whole report -- turning a
-          # large finding into no notification at all, which is the failure this workflow
-          # exists to prevent. Keep the head and tail and say what was dropped.
-          limit=45000
+          # verbose output can pass that, and gh would fail the report entirely -- turning
+          # a large finding into no notification, the exact failure this exists to
+          # prevent. Keep the head and tail and say what was dropped.
           if [ ! -s "${RUNNER_TEMP}/report.txt" ]; then
             body_output="(govulncheck produced no output -- the job failed before or during the scan; see the run log.)"
-          elif [ "$(wc -c < "${RUNNER_TEMP}/report.txt")" -gt "${limit}" ]; then
+          elif [ "$(wc -c < "${RUNNER_TEMP}/report.txt")" -gt 45000 ]; then
             body_output="$(head -c 22000 "${RUNNER_TEMP}/report.txt")
 
           [... truncated to fit GitHub's 65536-character limit -- full output in the run log ...]
@@ -353,7 +339,7 @@ jobs:
           {
             echo "${headline}"
             echo
-            echo "Ref: \`${SCANNED_FULL_REF}\` @ \`${SCANNED_SHA}\`"
+            echo "Commit: \`${SCANNED_SHA}\`"
             echo "Targets: \`${TARGETS}\`"
             echo "Run: ${RUN_URL}"
             if [ -s "${RUNNER_TEMP}/new.txt" ]; then
@@ -377,13 +363,6 @@ jobs:
             echo "An entry marked \"accepted, but now fixed\" means an ID in this workflow's ACCEPTED list has gained a fix for a module path we import: upgrade and drop the ID, rather than re-accepting it."
           } > "${RUNNER_TEMP}/body.md"
 
-          # Let a failure of the lookup itself stop the job rather than read as "no issue
-          # open", which would file a duplicate.
-          # The title carries a ref name, which git allows to contain quotes -- pass it to
-          # jq as data via $ENV rather than interpolating it into the jq program.
-          # $ENV.TITLE is expanded by jq, not by the shell -- that is the point of passing
-          # the title as data instead of interpolating it, so SC2016 is expected here.
-          # shellcheck disable=SC2016
           if [ -n "${existing}" ]; then
             gh issue comment "${existing}" --body-file "${RUNNER_TEMP}/body.md"
             echo "Updated issue #${existing}."

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -11,9 +11,11 @@ on:
 permissions: {}
 
 # The reporting step reads then writes the tracking issue, which is not atomic.
-# A manual dispatch overlapping the scheduled run could otherwise file two.
+# Keyed by ref because that is the unit of contention: each ref has its own
+# tracking issue, so runs on different refs never touch the same one, and only
+# same-ref runs -- which scan the same tree -- need to queue behind each other.
 concurrency:
-  group: ${{ github.workflow }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: false
 
 jobs:
@@ -269,6 +271,9 @@ jobs:
           OUTCOME: ${{ steps.scan.outputs.outcome }}
           TARGETS: "linux/amd64 linux/arm64 darwin/amd64 darwin/arm64"
           SCANNED_REF: ${{ github.ref_name }}
+          # A branch and a tag can share a short name; the full ref keeps their
+          # tracking issues apart.
+          SCANNED_FULL_REF: ${{ github.ref }}
           SCANNED_SHA: ${{ github.sha }}
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
         run: |
@@ -289,10 +294,14 @@ jobs:
           # A workflow_dispatch can target any ref, so never describe a run as being the
           # default branch without checking. Non-default refs get their own issue rather
           # than appending a branch-only finding to the canonical one.
-          if [ "${SCANNED_REF}" = "${DEFAULT_BRANCH}" ]; then
+          case "${SCANNED_FULL_REF}" in
+            refs/tags/*) ref_label="tag ${SCANNED_REF}" ;;
+            *)           ref_label="${SCANNED_REF}" ;;
+          esac
+          if [ "${SCANNED_FULL_REF}" = "refs/heads/${DEFAULT_BRANCH}" ]; then
             title="govulncheck: findings on ${DEFAULT_BRANCH}"
           else
-            title="govulncheck: findings on ${SCANNED_REF}"
+            title="govulncheck: findings on ${ref_label}"
           fi
           existing=$(lookup "${title}")
 
@@ -301,7 +310,7 @@ jobs:
           # tracking state is stale in the other direction.
           if [ "${OUTCOME}" = "clean" ]; then
             if [ -n "${existing}" ]; then
-              gh issue comment "${existing}" --body "The scheduled \`govulncheck\` run is clean again on \`${SCANNED_REF}\` @ \`${SCANNED_SHA}\` (targets \`${TARGETS}\`).
+              gh issue comment "${existing}" --body "The scheduled \`govulncheck\` run is clean again on \`${SCANNED_FULL_REF}\` @ \`${SCANNED_SHA}\` (targets \`${TARGETS}\`).
 
           Run: ${RUN_URL}
 
@@ -314,10 +323,21 @@ jobs:
             exit 0
           fi
 
-          if [ -s "${RUNNER_TEMP}/report.txt" ]; then
-            body_output=$(cat "${RUNNER_TEMP}/report.txt")
-          else
+          # GitHub caps an issue body or comment at 65536 characters. A dozen scans of
+          # verbose output can pass that, and gh would fail the whole report -- turning a
+          # large finding into no notification at all, which is the failure this workflow
+          # exists to prevent. Keep the head and tail and say what was dropped.
+          limit=45000
+          if [ ! -s "${RUNNER_TEMP}/report.txt" ]; then
             body_output="(govulncheck produced no output -- the job failed before or during the scan; see the run log.)"
+          elif [ "$(wc -c < "${RUNNER_TEMP}/report.txt")" -gt "${limit}" ]; then
+            body_output="$(head -c 22000 "${RUNNER_TEMP}/report.txt")
+
+          [... truncated to fit GitHub's 65536-character limit -- full output in the run log ...]
+
+          $(tail -c 22000 "${RUNNER_TEMP}/report.txt")"
+          else
+            body_output=$(cat "${RUNNER_TEMP}/report.txt")
           fi
 
           if [ "${OUTCOME}" = "vulnerable-and-error" ]; then
@@ -333,7 +353,7 @@ jobs:
           {
             echo "${headline}"
             echo
-            echo "Ref: \`${SCANNED_REF}\` @ \`${SCANNED_SHA}\`"
+            echo "Ref: \`${SCANNED_FULL_REF}\` @ \`${SCANNED_SHA}\`"
             echo "Targets: \`${TARGETS}\`"
             echo "Run: ${RUN_URL}"
             if [ -s "${RUNNER_TEMP}/new.txt" ]; then


### PR DESCRIPTION
This repo had no vulnerability scanning at all. That's how four Go standard library advisories sat against it unnoticed — I only found them because `basecamp/cli` runs govulncheck, went red, and prompted a check of the other Go repos. Nothing reported them here because nothing was looking.

**Merge #94 first** (the go1.26.7 bump). This job would fail on today's `main` — correctly, since `main` is still on the vulnerable toolchain.

### The accepted-findings list

This repo permanently carries two advisories that have no fix, so a plain `govulncheck ./...` would be red from day one — noise, not signal. The job therefore fails only on findings **not** in an explicit `ACCEPTED` list:

```
GO-2026-4887  Moby AuthZ plugin bypass on oversized request bodies
GO-2026-4883  Moby off-by-one in plugin privilege validation
```

Both are in `github.com/docker/docker`, which reports `Fixed in: N/A` — the fix exists only in `github.com/moby/moby/v2 >= 2.0.0-beta.8`, a module-path migration onto a beta. The reasoning is written into the workflow next to the list, so the next reader doesn't have to reconstruct it.

One correction to something I said on the bump PR: govulncheck reports these as reachable across **most of the docker client surface** we use (`ContainerCreate`, `ImagePull`, `Events`, …), not merely through error handling as I first described it. That doesn't change the conclusion — both bugs are in the *daemon's* plugin authorization and we're a client of the daemon, not a host of it — but the trace list is much broader than I characterized, and the workflow comment now says so accurately.

The filter matches govulncheck's own "Your code is affected by N vulnerabilities" line: it counts findings with a symbol-level trace, from `-format json`, minus the accepted IDs.

I verified it in both directions against this repo rather than trusting the shape:

| toolchain | ACCEPTED | result |
|---|---|---|
| go1.26.7 | the two above | exit 0, "No new reachable vulnerabilities" |
| go1.26.7 | empty | exit 1, flags both docker IDs |
| go1.26.5 | the two above | **exit 1, flags all four stdlib IDs** |

That third row is the one that matters: the accepted list silences exactly the two IDs named and nothing else — a new stdlib advisory still fails the job.

### Why scheduled and not a PR gate

A toolchain or dependency advisory is published against code that has not changed. Gating pull requests on it means the next CVE turns unrelated work red — which is precisely what happened to `basecamp/cli` today: its govulncheck job passed at 09:24 and, on the identical commit, failed an hour later. The clock is the right trigger; the diff isn't.

Runs daily, plus `workflow_dispatch` for on-demand. Times are staggered across the three repos.

### Why it opens an issue

A scheduled job that only goes red in the Actions tab is the same silence this exists to end — GitHub's failure notifications for cron workflows go to whoever last touched the schedule, which isn't a team signal. So a failing run files one issue, labelled `govulncheck`, with the run URL and the full output. It files **one at a time**: if a `govulncheck` issue is already open, the finding is already visible and it won't pile on.

Permissions are `contents: read` + `issues: write`, scoped to the job, under a top-level `permissions: {}`. Schedules only run on the default branch, so no untrusted PR code reaches that token.

### Verification

`actionlint` 1.7.12 and `zizmor` 1.29.0 (default persona, online) both report clean on the new file.
