### PR TITLE
Show a clear error when Docker is unreachable

### DIFF
--- a/cmd/once/main.go
+++ b/cmd/once/main.go
@@ -1,9 +1,11 @@
 package main
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/basecamp/once/internal/command"
+	"github.com/basecamp/once/internal/docker"
 	"github.com/basecamp/once/internal/logging"
 )
 
@@ -14,6 +16,7 @@ func main() {
 		if code, ok := command.ExitCode(err); ok {
 			os.Exit(code)
 		}
+		fmt.Fprintln(os.Stderr, "Error:", docker.ErrorMessage(err))
 		os.Exit(1)
 	}
 }

--- a/internal/command/exec.go
+++ b/internal/command/exec.go
@@ -33,13 +33,9 @@ func (e *execCommand) run(ctx context.Context, ns *docker.Namespace, cmd *cobra.
 		return err
 	}
 
-	err = withApplication(ns, host, "executing command in", func(app *docker.Application) error {
+	return withApplication(ns, host, "executing command in", func(app *docker.Application) error {
 		return app.Exec(ctx, commandArgs)
 	})
-	if IsExitError(err) {
-		cmd.SilenceErrors = true
-	}
-	return err
 }
 
 // Helpers

--- a/internal/command/root.go
+++ b/internal/command/root.go
@@ -22,9 +22,10 @@ type RootCommand struct {
 func NewRootCommand() *RootCommand {
 	r := &RootCommand{}
 	r.cmd = &cobra.Command{
-		Use:          "once",
-		Short:        "Manage web applications from Docker images",
-		SilenceUsage: true,
+		Use:           "once",
+		Short:         "Manage web applications from Docker images",
+		SilenceUsage:  true,
+		SilenceErrors: true,
 		CompletionOptions: cobra.CompletionOptions{
 			HiddenDefaultCmd: true,
 		},

--- a/internal/docker/errors.go
+++ b/internal/docker/errors.go
@@ -2,7 +2,11 @@ package docker
 
 import (
 	"errors"
+	"fmt"
+	"os"
 	"strings"
+
+	"github.com/docker/docker/client"
 )
 
 type DescribedError interface {
@@ -18,6 +22,14 @@ var (
 	ErrAppNotStarted = &describedError{
 		msg:         "application did not start",
 		description: "The application did not start within the time limit. Check the application logs for errors.",
+	}
+	ErrDockerPermissionDenied = &describedError{
+		msg:         "permission denied connecting to Docker",
+		description: "Permission denied when connecting to the Docker socket. Run with `sudo`, or add yourself to the `docker` group.",
+	}
+	ErrDockerNotRunning = &describedError{
+		msg:         "cannot connect to Docker",
+		description: "Could not connect to Docker. Make sure Docker is installed and the Docker daemon is running.",
 	}
 )
 
@@ -48,4 +60,17 @@ func isPortConflict(err error) bool {
 	msg := err.Error()
 	return strings.Contains(msg, "bind: address already in use") ||
 		strings.Contains(msg, "port is already allocated")
+}
+
+func connectionError(err error) error {
+	switch {
+	case err == nil:
+		return nil
+	case errors.Is(err, os.ErrPermission):
+		return fmt.Errorf("%w: %w", ErrDockerPermissionDenied, err)
+	case client.IsErrConnectionFailed(err):
+		return fmt.Errorf("%w: %w", ErrDockerNotRunning, err)
+	default:
+		return err
+	}
 }

--- a/internal/docker/errors_test.go
+++ b/internal/docker/errors_test.go
@@ -1,11 +1,17 @@
 package docker
 
 import (
+	"context"
 	"errors"
 	"fmt"
+	"net"
+	"os"
+	"path/filepath"
 	"testing"
 
+	"github.com/docker/docker/client"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestIsPortConflict(t *testing.T) {
@@ -28,5 +34,44 @@ func TestErrorMessage(t *testing.T) {
 	t.Run("returns Error for plain error", func(t *testing.T) {
 		err := errors.New("something broke")
 		assert.Equal(t, "something broke", ErrorMessage(err))
+	})
+}
+
+func TestConnectionError(t *testing.T) {
+	pingError := func(t *testing.T, socketPath string) error {
+		c, err := client.NewClientWithOpts(client.WithHost("unix://" + socketPath))
+		require.NoError(t, err)
+		_, err = c.Ping(context.Background())
+		require.Error(t, err)
+		return err
+	}
+
+	t.Run("permission denied", func(t *testing.T) {
+		if os.Getuid() == 0 {
+			t.Skip("root can always connect to the socket")
+		}
+
+		socketPath := filepath.Join(t.TempDir(), "docker.sock")
+		listener, err := net.Listen("unix", socketPath)
+		require.NoError(t, err)
+		defer listener.Close()
+		require.NoError(t, os.Chmod(socketPath, 0))
+
+		err = connectionError(pingError(t, socketPath))
+		assert.ErrorIs(t, err, ErrDockerPermissionDenied)
+		assert.Equal(t, ErrDockerPermissionDenied.Description(), ErrorMessage(err))
+	})
+
+	t.Run("daemon not running", func(t *testing.T) {
+		socketPath := filepath.Join(t.TempDir(), "missing.sock")
+
+		err := connectionError(pingError(t, socketPath))
+		assert.ErrorIs(t, err, ErrDockerNotRunning)
+		assert.Equal(t, ErrDockerNotRunning.Description(), ErrorMessage(err))
+	})
+
+	t.Run("passes through other errors", func(t *testing.T) {
+		assert.Equal(t, assert.AnError, connectionError(assert.AnError))
+		assert.NoError(t, connectionError(nil))
 	})
 }

--- a/internal/docker/namespace.go
+++ b/internal/docker/namespace.go
@@ -290,7 +290,7 @@ type appCandidate struct {
 func (n *Namespace) restoreState(ctx context.Context) error {
 	containers, err := n.client.ContainerList(ctx, container.ListOptions{All: true})
 	if err != nil {
-		return err
+		return connectionError(err)
 	}
 
 	proxyPrefix := n.name + "-proxy"


### PR DESCRIPTION
Wrap the first Docker API failure in a DescribedError, so a permission denied error on the socket tells the user to use sudo or join the docker group, and a connection failure says the daemon is not running.

Silence cobra's default error output and print the described message from main instead, so the CLI shows the same friendly text as the TUI.