### PR TITLE
Enforce import grouping with gci

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,6 +3,13 @@ version: "2"
 formatters:
   enable:
     - gofmt
+    - gci
+  settings:
+    gci:
+      sections:
+        - standard
+        - default
+        - localmodule
 
 linters:
   enable:

--- a/internal/ui/actions_menu_test.go
+++ b/internal/ui/actions_menu_test.go
@@ -6,10 +6,10 @@ import (
 
 	tea "charm.land/bubbletea/v2"
 	"github.com/charmbracelet/x/ansi"
-
-	"github.com/basecamp/once/internal/docker"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/basecamp/once/internal/docker"
 )
 
 func TestActionsMenu_ShowsStopWhenRunning(t *testing.T) {

--- a/internal/ui/install_test.go
+++ b/internal/ui/install_test.go
@@ -7,10 +7,10 @@ import (
 
 	tea "charm.land/bubbletea/v2"
 	"github.com/charmbracelet/x/ansi"
-
-	"github.com/basecamp/once/internal/docker"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/basecamp/once/internal/docker"
 )
 
 func TestInstall_KnownAppFlow(t *testing.T) {

--- a/internal/ui/remove_test.go
+++ b/internal/ui/remove_test.go
@@ -5,10 +5,10 @@ import (
 	"testing"
 
 	tea "charm.land/bubbletea/v2"
-
-	"github.com/basecamp/once/internal/docker"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/basecamp/once/internal/docker"
 )
 
 func TestRemove_ViewShowsConfirmation(t *testing.T) {

--- a/internal/ui/settings_menu_test.go
+++ b/internal/ui/settings_menu_test.go
@@ -4,10 +4,11 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/basecamp/once/internal/docker"
 	"github.com/charmbracelet/x/ansi"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/basecamp/once/internal/docker"
 )
 
 func TestSettingsMenu_TitleCentered(t *testing.T) {


### PR DESCRIPTION
Add the gci formatter to golangci-lint, with sections for stdlib, 3rd-party, and local module imports. Fix the four test files in internal/ui that placed a project import in the 3rd-party group.