### PR TITLE
Add mise.toml with the project's dev tools

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,4 @@
+[tools]
+go = "latest"
+golangci-lint = "latest"
+"go:golang.org/x/vuln/cmd/govulncheck" = "latest"


### PR DESCRIPTION
Adds a minimal mise config so contributors who use mise get the everyday Makefile tools with `mise install`:

- `go = "latest"` — bootstraps a compiler; `go.mod` remains the single source for the exact Go version (the toolchain directive downloads it as needed)
- `golangci-lint` — for `make lint`
- `govulncheck` — for `make check` (via mise's go backend; the registry has no short name for it)

Left out on purpose:
- `actionlint` / `zizmor` (`make lint-actions`) — CI runs these
- `gh` (`make test-release`) — commonly installed already; a mise copy could shadow it

Verified locally: `mise install` then `make lint` and `make check` both pass.