### PR TITLE
App-specific registry credentials

### DIFF
--- a/integration/docker_test.go
+++ b/integration/docker_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/mutate"
@@ -36,6 +37,14 @@ import (
 )
 
 const integrationAppImageRef = "ghcr.io/basecamp/once-integration-app:latest"
+
+const (
+	testRegistryUsername = "registry-user"
+	testRegistryPassword = "registry-pass"
+	// bcrypt hash of testRegistryPassword, precomputed to avoid an x/crypto
+	// dependency just for the tests.
+	testRegistryPasswordBcrypt = "$2a$04$.2i9XCuXxcT5AaEtj6kY/.7hDz3xxJQYoIArvlIH6FEZssMVJofZa"
+)
 
 // Pre-pull shared images so parallel tests don't all block on the same pull
 // inside their own timeouts.
@@ -252,6 +261,41 @@ func TestUpdateDetectsLocalImageChange(t *testing.T) {
 	secondContainer, err := app.ContainerName(ctx)
 	require.NoError(t, err)
 	assert.NotEqual(t, firstContainer, secondContainer, "container should change after update")
+}
+
+func TestDeployWithRegistryCredentials(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	registryURL := startAuthedLocalRegistry(t, ctx)
+	imageRef := registryURL + "/authapp:latest"
+	pushToRegistry(t, ctx, imageRef, baseImage(t, ctx),
+		remote.WithAuth(&authn.Basic{Username: testRegistryUsername, Password: testRegistryPassword}))
+
+	ns := newTestNamespace(t, "once-registry-auth-test")
+
+	require.NoError(t, ns.EnsureNetwork(ctx))
+	require.NoError(t, ns.Proxy().Boot(ctx, getProxyPorts(t)))
+
+	settings := docker.ApplicationSettings{
+		Name:  "authapp",
+		Image: imageRef,
+		Host:  "authapp.localhost",
+	}
+
+	noCreds := docker.NewApplication(ns, settings)
+	require.ErrorIs(t, noCreds.Deploy(ctx, nil), docker.ErrPullFailed)
+
+	settings.Registry = docker.RegistrySettings{
+		Image:    imageRef,
+		Username: testRegistryUsername,
+		Password: testRegistryPassword,
+	}
+	app := deployApp(t, ctx, ns, settings)
+	require.NotNil(t, app)
+	assert.Equal(t, settings.Registry, app.Settings.Registry)
 }
 
 func TestLargeLabelData(t *testing.T) {
@@ -1263,6 +1307,20 @@ func collectPauseEvents(t *testing.T, ctx context.Context, containerName string)
 }
 
 func startLocalRegistry(t *testing.T, ctx context.Context) string {
+	return startRegistry(t, ctx, "")
+}
+
+// startAuthedLocalRegistry starts a registry that requires basic auth with
+// testRegistryUsername and testRegistryPassword.
+func startAuthedLocalRegistry(t *testing.T, ctx context.Context) string {
+	t.Helper()
+	htpasswdPath := filepath.Join(t.TempDir(), "htpasswd")
+	entry := testRegistryUsername + ":" + testRegistryPasswordBcrypt + "\n"
+	require.NoError(t, os.WriteFile(htpasswdPath, []byte(entry), 0644))
+	return startRegistry(t, ctx, htpasswdPath)
+}
+
+func startRegistry(t *testing.T, ctx context.Context, htpasswdPath string) string {
 	t.Helper()
 	c, err := client.New(client.FromEnv)
 	require.NoError(t, err)
@@ -1276,14 +1334,25 @@ func startLocalRegistry(t *testing.T, ctx context.Context) string {
 	port := getFreePort(t)
 	portStr := strconv.Itoa(port)
 
-	resp, err := c.ContainerCreate(ctx, client.ContainerCreateOptions{
-		Name:   fmt.Sprintf("test-registry-%s", portStr),
-		Config: &container.Config{Image: "registry:2"},
-		HostConfig: &container.HostConfig{
-			PortBindings: network.PortMap{
-				network.MustParsePort("5000/tcp"): []network.PortBinding{{HostPort: portStr}},
-			},
+	config := &container.Config{Image: "registry:2"}
+	hostConfig := &container.HostConfig{
+		PortBindings: network.PortMap{
+			network.MustParsePort("5000/tcp"): []network.PortBinding{{HostPort: portStr}},
 		},
+	}
+	if htpasswdPath != "" {
+		config.Env = []string{
+			"REGISTRY_AUTH=htpasswd",
+			"REGISTRY_AUTH_HTPASSWD_REALM=test-registry",
+			"REGISTRY_AUTH_HTPASSWD_PATH=/auth/htpasswd",
+		}
+		hostConfig.Binds = []string{htpasswdPath + ":/auth/htpasswd:ro"}
+	}
+
+	resp, err := c.ContainerCreate(ctx, client.ContainerCreateOptions{
+		Name:       fmt.Sprintf("test-registry-%s", portStr),
+		Config:     config,
+		HostConfig: hostConfig,
 	})
 	require.NoError(t, err)
 	t.Cleanup(func() {
@@ -1300,7 +1369,9 @@ func startLocalRegistry(t *testing.T, ctx context.Context) string {
 			return false
 		}
 		resp.Body.Close()
-		return resp.StatusCode == http.StatusOK
+		// An authed registry answers 401 until credentials are supplied;
+		// either status means it's up.
+		return resp.StatusCode == http.StatusOK || resp.StatusCode == http.StatusUnauthorized
 	}, 10*time.Second, 200*time.Millisecond, "registry did not become ready")
 
 	return registryURL
@@ -1345,12 +1416,12 @@ func baseImage(t *testing.T, ctx context.Context) v1.Image {
 	return img
 }
 
-func pushToRegistry(t *testing.T, ctx context.Context, tag string, img v1.Image) {
+func pushToRegistry(t *testing.T, ctx context.Context, tag string, img v1.Image, opts ...remote.Option) {
 	t.Helper()
 
 	ref, err := name.ParseReference(tag)
 	require.NoError(t, err)
-	require.NoError(t, remote.Write(ref, img, remote.WithContext(ctx)))
+	require.NoError(t, remote.Write(ref, img, append([]remote.Option{remote.WithContext(ctx)}, opts...)...))
 }
 
 func buildTestBackup(t *testing.T, imageName string) []byte {

--- a/integration/docker_test.go
+++ b/integration/docker_test.go
@@ -288,8 +288,10 @@ func TestDeployWithRegistryCredentials(t *testing.T) {
 	noCreds := docker.NewApplication(ns, settings)
 	require.ErrorIs(t, noCreds.Deploy(ctx, nil), docker.ErrPullFailed)
 
+	registryHost, err := docker.RegistryHost(imageRef)
+	require.NoError(t, err)
 	settings.Registry = docker.RegistrySettings{
-		Image:    imageRef,
+		Host:     registryHost,
 		Username: testRegistryUsername,
 		Password: testRegistryPassword,
 	}

--- a/integration/docker_test.go
+++ b/integration/docker_test.go
@@ -286,7 +286,9 @@ func TestDeployWithRegistryCredentials(t *testing.T) {
 	}
 
 	noCreds := docker.NewApplication(ns, settings)
-	require.ErrorIs(t, noCreds.Deploy(ctx, nil), docker.ErrPullFailed)
+	err := noCreds.Deploy(ctx, nil)
+	require.ErrorIs(t, err, docker.ErrPullFailed)
+	require.ErrorIs(t, err, docker.ErrPullMaybeUnauthorized)
 
 	registryHost, err := docker.RegistryHost(imageRef)
 	require.NoError(t, err)

--- a/internal/command/deploy.go
+++ b/internal/command/deploy.go
@@ -47,7 +47,7 @@ func (d *deployCommand) run(ctx context.Context, ns *docker.Namespace, cmd *cobr
 		return docker.ErrHostnameInUse
 	}
 
-	settings, err := d.flags.buildSettings(imageRef, host)
+	settings, err := d.flags.buildSettings(cmd, imageRef, host)
 	if err != nil {
 		return err
 	}

--- a/internal/command/deploy_test.go
+++ b/internal/command/deploy_test.go
@@ -102,7 +102,7 @@ func TestBuildSettingsRegistry(t *testing.T) {
 
 		s, err := f.buildSettings(cmd, "image:latest", "app.example.com")
 		require.NoError(t, err)
-		assert.Equal(t, docker.RegistrySettings{Image: "image:latest", Username: "user", Password: "pass"}, s.Registry)
+		assert.Equal(t, docker.RegistrySettings{Host: "index.docker.io", Username: "user", Password: "pass"}, s.Registry)
 	})
 
 	t.Run("password from stdin trims the trailing newline", func(t *testing.T) {

--- a/internal/command/deploy_test.go
+++ b/internal/command/deploy_test.go
@@ -1,8 +1,10 @@
 package command
 
 import (
+	"strings"
 	"testing"
 
+	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -60,20 +62,81 @@ func TestParseEnvVars(t *testing.T) {
 
 func TestBuildSettingsImageRequired(t *testing.T) {
 	f := &settingsFlags{}
-	_, err := f.buildSettings("", "app.example.com")
+	_, err := f.buildSettings(&cobra.Command{}, "", "app.example.com")
 	assert.ErrorIs(t, err, docker.ErrImageRequired)
 }
 
 func TestBuildSettingsAutoBackupRequiresPath(t *testing.T) {
 	t.Run("auto-backup without path", func(t *testing.T) {
 		f := &settingsFlags{autoBackup: true}
-		_, err := f.buildSettings("image:latest", "app.example.com")
+		_, err := f.buildSettings(&cobra.Command{}, "image:latest", "app.example.com")
 		assert.ErrorIs(t, err, docker.ErrAutoBackupWithoutPath)
 	})
 
 	t.Run("auto-backup with path", func(t *testing.T) {
 		f := &settingsFlags{autoBackup: true, backupPath: "/backups"}
-		_, err := f.buildSettings("image:latest", "app.example.com")
+		_, err := f.buildSettings(&cobra.Command{}, "image:latest", "app.example.com")
 		require.NoError(t, err)
+	})
+}
+
+func TestBuildSettingsRegistry(t *testing.T) {
+	newCmd := func() (*cobra.Command, *settingsFlags) {
+		cmd := &cobra.Command{}
+		f := &settingsFlags{}
+		f.register(cmd)
+		return cmd, f
+	}
+
+	t.Run("no registry flags leaves registry empty", func(t *testing.T) {
+		cmd, f := newCmd()
+		s, err := f.buildSettings(cmd, "image:latest", "app.example.com")
+		require.NoError(t, err)
+		assert.True(t, s.Registry.Empty())
+	})
+
+	t.Run("username and password set the scoped credentials", func(t *testing.T) {
+		cmd, f := newCmd()
+		require.NoError(t, cmd.Flags().Set("registry-username", "user"))
+		require.NoError(t, cmd.Flags().Set("registry-password", "pass"))
+
+		s, err := f.buildSettings(cmd, "image:latest", "app.example.com")
+		require.NoError(t, err)
+		assert.Equal(t, docker.RegistrySettings{Image: "image:latest", Username: "user", Password: "pass"}, s.Registry)
+	})
+
+	t.Run("password from stdin trims the trailing newline", func(t *testing.T) {
+		cmd, f := newCmd()
+		cmd.SetIn(strings.NewReader("hunter2\n"))
+		require.NoError(t, cmd.Flags().Set("registry-username", "user"))
+		require.NoError(t, cmd.Flags().Set("registry-password-stdin", "true"))
+
+		s, err := f.buildSettings(cmd, "image:latest", "app.example.com")
+		require.NoError(t, err)
+		assert.Equal(t, "hunter2", s.Registry.Password)
+	})
+
+	t.Run("password without username", func(t *testing.T) {
+		cmd, f := newCmd()
+		require.NoError(t, cmd.Flags().Set("registry-password", "pass"))
+
+		_, err := f.buildSettings(cmd, "image:latest", "app.example.com")
+		assert.ErrorIs(t, err, docker.ErrRegistryPasswordWithoutUsername)
+	})
+
+	t.Run("username without password", func(t *testing.T) {
+		cmd, f := newCmd()
+		require.NoError(t, cmd.Flags().Set("registry-username", "user"))
+
+		_, err := f.buildSettings(cmd, "image:latest", "app.example.com")
+		assert.ErrorIs(t, err, docker.ErrRegistryUsernameWithoutPassword)
+	})
+
+	t.Run("password and password-stdin are mutually exclusive", func(t *testing.T) {
+		cmd, _ := newCmd()
+		require.NoError(t, cmd.Flags().Set("registry-password", "pass"))
+		require.NoError(t, cmd.Flags().Set("registry-password-stdin", "true"))
+
+		assert.Error(t, cmd.ValidateFlagGroups())
 	})
 }

--- a/internal/command/settings_flags.go
+++ b/internal/command/settings_flags.go
@@ -89,8 +89,12 @@ func (f *settingsFlags) buildSettings(cmd *cobra.Command, image, host string) (d
 		if err != nil {
 			return docker.ApplicationSettings{}, err
 		}
+		host, err := docker.RegistryHost(image)
+		if err != nil {
+			return docker.ApplicationSettings{}, err
+		}
 		s.Registry = docker.RegistrySettings{
-			Image:    image,
+			Host:     host,
 			Username: f.registryUsername,
 			Password: password,
 		}
@@ -155,16 +159,24 @@ func (f *settingsFlags) applyChanges(cmd *cobra.Command, existing docker.Applica
 		s.Backup.AutoBackup = f.autoBackup
 	}
 	if cmd.Flags().Changed("registry-username") {
+		host, err := docker.RegistryHost(image)
+		if err != nil {
+			return s, err
+		}
 		s.Registry.Username = f.registryUsername
-		s.Registry.Image = image
+		s.Registry.Host = host
 	}
 	if cmd.Flags().Changed("registry-password") || cmd.Flags().Changed("registry-password-stdin") {
 		password, err := f.registryPasswordValue(cmd)
 		if err != nil {
 			return s, err
 		}
+		host, err := docker.RegistryHost(image)
+		if err != nil {
+			return s, err
+		}
 		s.Registry.Password = password
-		s.Registry.Image = image
+		s.Registry.Host = host
 	}
 	if s.Registry.Username == "" && s.Registry.Password == "" {
 		s.Registry = docker.RegistrySettings{}

--- a/internal/command/settings_flags.go
+++ b/internal/command/settings_flags.go
@@ -158,15 +158,17 @@ func (f *settingsFlags) applyChanges(cmd *cobra.Command, existing docker.Applica
 	if cmd.Flags().Changed("auto-backup") {
 		s.Backup.AutoBackup = f.autoBackup
 	}
-	if cmd.Flags().Changed("registry-username") {
-		host, err := docker.RegistryHost(image)
-		if err != nil {
-			return s, err
+	usernameChanged := cmd.Flags().Changed("registry-username")
+	passwordChanged := cmd.Flags().Changed("registry-password") || cmd.Flags().Changed("registry-password-stdin")
+	if usernameChanged != passwordChanged {
+		// Requiring the pair prevents re-scoping a stored credential to a
+		// new registry host alongside a partial update.
+		if usernameChanged {
+			return s, docker.ErrRegistryUsernameWithoutPassword
 		}
-		s.Registry.Username = f.registryUsername
-		s.Registry.Host = host
+		return s, docker.ErrRegistryPasswordWithoutUsername
 	}
-	if cmd.Flags().Changed("registry-password") || cmd.Flags().Changed("registry-password-stdin") {
+	if usernameChanged {
 		password, err := f.registryPasswordValue(cmd)
 		if err != nil {
 			return s, err
@@ -175,11 +177,14 @@ func (f *settingsFlags) applyChanges(cmd *cobra.Command, existing docker.Applica
 		if err != nil {
 			return s, err
 		}
-		s.Registry.Password = password
-		s.Registry.Host = host
-	}
-	if s.Registry.Username == "" && s.Registry.Password == "" {
-		s.Registry = docker.RegistrySettings{}
+		s.Registry = docker.RegistrySettings{
+			Host:     host,
+			Username: f.registryUsername,
+			Password: password,
+		}
+		if f.registryUsername == "" && password == "" {
+			s.Registry = docker.RegistrySettings{}
+		}
 	}
 
 	if err := s.Validate(); err != nil {

--- a/internal/command/settings_flags.go
+++ b/internal/command/settings_flags.go
@@ -2,6 +2,7 @@ package command
 
 import (
 	"fmt"
+	"io"
 	"path/filepath"
 	"strings"
 
@@ -24,6 +25,10 @@ type settingsFlags struct {
 	autoUpdate   bool
 	backupPath   string
 	autoBackup   bool
+
+	registryUsername      string
+	registryPassword      string
+	registryPasswordStdin bool
 }
 
 func (f *settingsFlags) register(cmd *cobra.Command) {
@@ -40,9 +45,13 @@ func (f *settingsFlags) register(cmd *cobra.Command) {
 	cmd.Flags().BoolVar(&f.autoUpdate, "auto-update", true, "automatically update the application")
 	cmd.Flags().StringVar(&f.backupPath, "backup-path", "", "path for backups")
 	cmd.Flags().BoolVar(&f.autoBackup, "auto-backup", false, "enable automatic backups")
+	cmd.Flags().StringVar(&f.registryUsername, "registry-username", "", "registry username for pulling the application image")
+	cmd.Flags().StringVar(&f.registryPassword, "registry-password", "", "registry password for pulling the application image")
+	cmd.Flags().BoolVar(&f.registryPasswordStdin, "registry-password-stdin", false, "read the registry password from stdin")
+	cmd.MarkFlagsMutuallyExclusive("registry-password", "registry-password-stdin")
 }
 
-func (f *settingsFlags) buildSettings(image, host string) (docker.ApplicationSettings, error) {
+func (f *settingsFlags) buildSettings(cmd *cobra.Command, image, host string) (docker.ApplicationSettings, error) {
 	envVars, err := f.parseEnvVars()
 	if err != nil {
 		return docker.ApplicationSettings{}, err
@@ -73,6 +82,18 @@ func (f *settingsFlags) buildSettings(image, host string) (docker.ApplicationSet
 			Path:       f.backupPath,
 			AutoBackup: f.autoBackup,
 		},
+	}
+
+	if f.registryUsername != "" || f.registryPassword != "" || f.registryPasswordStdin {
+		password, err := f.registryPasswordValue(cmd)
+		if err != nil {
+			return docker.ApplicationSettings{}, err
+		}
+		s.Registry = docker.RegistrySettings{
+			Image:    image,
+			Username: f.registryUsername,
+			Password: password,
+		}
 	}
 
 	if err := s.Validate(); err != nil {
@@ -133,12 +154,38 @@ func (f *settingsFlags) applyChanges(cmd *cobra.Command, existing docker.Applica
 	if cmd.Flags().Changed("auto-backup") {
 		s.Backup.AutoBackup = f.autoBackup
 	}
+	if cmd.Flags().Changed("registry-username") {
+		s.Registry.Username = f.registryUsername
+		s.Registry.Image = image
+	}
+	if cmd.Flags().Changed("registry-password") || cmd.Flags().Changed("registry-password-stdin") {
+		password, err := f.registryPasswordValue(cmd)
+		if err != nil {
+			return s, err
+		}
+		s.Registry.Password = password
+		s.Registry.Image = image
+	}
+	if s.Registry.Username == "" && s.Registry.Password == "" {
+		s.Registry = docker.RegistrySettings{}
+	}
 
 	if err := s.Validate(); err != nil {
 		return s, err
 	}
 
 	return s, nil
+}
+
+func (f *settingsFlags) registryPasswordValue(cmd *cobra.Command) (string, error) {
+	if !f.registryPasswordStdin {
+		return f.registryPassword, nil
+	}
+	b, err := io.ReadAll(cmd.InOrStdin())
+	if err != nil {
+		return "", fmt.Errorf("reading registry password from stdin: %w", err)
+	}
+	return strings.TrimRight(string(b), "\r\n"), nil
 }
 
 func (f *settingsFlags) parseEnvVars() (map[string]string, error) {

--- a/internal/command/update_test.go
+++ b/internal/command/update_test.go
@@ -1,6 +1,7 @@
 package command
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/spf13/cobra"
@@ -132,6 +133,62 @@ func TestApplyChanges(t *testing.T) {
 
 		_, err := f.applyChanges(cmd, existing, existing.Image)
 		assert.ErrorIs(t, err, docker.ErrAutoBackupWithoutPath)
+	})
+
+	t.Run("registry credentials scope to the effective image", func(t *testing.T) {
+		cmd, f := newCmd()
+		require.NoError(t, cmd.Flags().Set("registry-username", "user"))
+		require.NoError(t, cmd.Flags().Set("registry-password", "pass"))
+
+		result, err := f.applyChanges(cmd, existing, "otherimage:latest")
+		require.NoError(t, err)
+		assert.Equal(t, docker.RegistrySettings{Image: "otherimage:latest", Username: "user", Password: "pass"}, result.Registry)
+	})
+
+	t.Run("registry password from stdin", func(t *testing.T) {
+		withCreds := existing
+		withCreds.Registry = docker.RegistrySettings{Image: existing.Image, Username: "user", Password: "old"}
+
+		cmd, f := newCmd()
+		cmd.SetIn(strings.NewReader("newpass\n"))
+		require.NoError(t, cmd.Flags().Set("registry-password-stdin", "true"))
+
+		result, err := f.applyChanges(cmd, withCreds, withCreds.Image)
+		require.NoError(t, err)
+		assert.Equal(t, "newpass", result.Registry.Password)
+		assert.Equal(t, "user", result.Registry.Username)
+	})
+
+	t.Run("image change alone keeps existing registry scope", func(t *testing.T) {
+		withCreds := existing
+		withCreds.Registry = docker.RegistrySettings{Image: existing.Image, Username: "user", Password: "pass"}
+
+		cmd, f := newCmd()
+		result, err := f.applyChanges(cmd, withCreds, "otherimage:latest")
+		require.NoError(t, err)
+		assert.Equal(t, withCreds.Registry, result.Registry)
+		assert.Equal(t, "otherimage:latest", result.Image)
+	})
+
+	t.Run("empty credentials clear the registry settings", func(t *testing.T) {
+		withCreds := existing
+		withCreds.Registry = docker.RegistrySettings{Image: existing.Image, Username: "user", Password: "pass"}
+
+		cmd, f := newCmd()
+		require.NoError(t, cmd.Flags().Set("registry-username", ""))
+		require.NoError(t, cmd.Flags().Set("registry-password", ""))
+
+		result, err := f.applyChanges(cmd, withCreds, withCreds.Image)
+		require.NoError(t, err)
+		assert.True(t, result.Registry.Empty())
+	})
+
+	t.Run("partial registry credentials return an error", func(t *testing.T) {
+		cmd, f := newCmd()
+		require.NoError(t, cmd.Flags().Set("registry-password", "pass"))
+
+		_, err := f.applyChanges(cmd, existing, existing.Image)
+		assert.ErrorIs(t, err, docker.ErrRegistryPasswordWithoutUsername)
 	})
 
 	t.Run("set both auto-backup and path", func(t *testing.T) {

--- a/internal/command/update_test.go
+++ b/internal/command/update_test.go
@@ -135,19 +135,19 @@ func TestApplyChanges(t *testing.T) {
 		assert.ErrorIs(t, err, docker.ErrAutoBackupWithoutPath)
 	})
 
-	t.Run("registry credentials scope to the effective image", func(t *testing.T) {
+	t.Run("registry credentials scope to the effective image's host", func(t *testing.T) {
 		cmd, f := newCmd()
 		require.NoError(t, cmd.Flags().Set("registry-username", "user"))
 		require.NoError(t, cmd.Flags().Set("registry-password", "pass"))
 
-		result, err := f.applyChanges(cmd, existing, "otherimage:latest")
+		result, err := f.applyChanges(cmd, existing, "ghcr.io/otherimage:latest")
 		require.NoError(t, err)
-		assert.Equal(t, docker.RegistrySettings{Image: "otherimage:latest", Username: "user", Password: "pass"}, result.Registry)
+		assert.Equal(t, docker.RegistrySettings{Host: "ghcr.io", Username: "user", Password: "pass"}, result.Registry)
 	})
 
 	t.Run("registry password from stdin", func(t *testing.T) {
 		withCreds := existing
-		withCreds.Registry = docker.RegistrySettings{Image: existing.Image, Username: "user", Password: "old"}
+		withCreds.Registry = docker.RegistrySettings{Host: "index.docker.io", Username: "user", Password: "old"}
 
 		cmd, f := newCmd()
 		cmd.SetIn(strings.NewReader("newpass\n"))
@@ -161,7 +161,7 @@ func TestApplyChanges(t *testing.T) {
 
 	t.Run("image change alone keeps existing registry scope", func(t *testing.T) {
 		withCreds := existing
-		withCreds.Registry = docker.RegistrySettings{Image: existing.Image, Username: "user", Password: "pass"}
+		withCreds.Registry = docker.RegistrySettings{Host: "index.docker.io", Username: "user", Password: "pass"}
 
 		cmd, f := newCmd()
 		result, err := f.applyChanges(cmd, withCreds, "otherimage:latest")
@@ -172,7 +172,7 @@ func TestApplyChanges(t *testing.T) {
 
 	t.Run("empty credentials clear the registry settings", func(t *testing.T) {
 		withCreds := existing
-		withCreds.Registry = docker.RegistrySettings{Image: existing.Image, Username: "user", Password: "pass"}
+		withCreds.Registry = docker.RegistrySettings{Host: "index.docker.io", Username: "user", Password: "pass"}
 
 		cmd, f := newCmd()
 		require.NoError(t, cmd.Flags().Set("registry-username", ""))

--- a/internal/command/update_test.go
+++ b/internal/command/update_test.go
@@ -151,12 +151,26 @@ func TestApplyChanges(t *testing.T) {
 
 		cmd, f := newCmd()
 		cmd.SetIn(strings.NewReader("newpass\n"))
+		require.NoError(t, cmd.Flags().Set("registry-username", "user"))
 		require.NoError(t, cmd.Flags().Set("registry-password-stdin", "true"))
 
 		result, err := f.applyChanges(cmd, withCreds, withCreds.Image)
 		require.NoError(t, err)
 		assert.Equal(t, "newpass", result.Registry.Password)
 		assert.Equal(t, "user", result.Registry.Username)
+	})
+
+	t.Run("username alone is rejected even with stored credentials", func(t *testing.T) {
+		// Otherwise a username change plus a new image host would re-scope
+		// the stored password to a different registry.
+		withCreds := existing
+		withCreds.Registry = docker.RegistrySettings{Host: "index.docker.io", Username: "user", Password: "pass"}
+
+		cmd, f := newCmd()
+		require.NoError(t, cmd.Flags().Set("registry-username", "newuser"))
+
+		_, err := f.applyChanges(cmd, withCreds, "ghcr.io/otherimage:latest")
+		assert.ErrorIs(t, err, docker.ErrRegistryUsernameWithoutPassword)
 	})
 
 	t.Run("image change alone keeps existing registry scope", func(t *testing.T) {

--- a/internal/docker/application.go
+++ b/internal/docker/application.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io"
 	"log/slog"
 	"net/http"
 	"strconv"
@@ -32,6 +31,10 @@ var (
 	ErrPullFailed            = &describedError{
 		msg:         "pull failed",
 		description: "Failed to download the application image. Check that the image name is correct and try again.",
+	}
+	ErrPullMaybeUnauthorized = &describedError{
+		msg:         "image missing or authentication required",
+		description: "Could not pull the image. The image may not exist, or it may require registry credentials.",
 	}
 	ErrDeployFailed       = errors.New("deploy failed")
 	ErrVerificationFailed = &describedError{
@@ -296,19 +299,13 @@ func (a *Application) pullImage(ctx context.Context, progress DeployProgressCall
 	opts := client.ImagePullOptions{RegistryAuth: registryAuthFor(a.Settings)}
 	reader, err := a.namespace.client.ImagePull(ctx, a.Settings.Image, opts)
 	if err != nil {
-		return false, fmt.Errorf("%w: %w", ErrPullFailed, err)
+		return false, wrapPullError(err)
 	}
 	defer reader.Close()
 
-	if progress != nil {
-		tracker := newPullProgressTracker(progress)
-		if err := tracker.Track(reader); err != nil {
-			return false, fmt.Errorf("%w: %w", ErrPullFailed, err)
-		}
-	} else {
-		if _, err := io.Copy(io.Discard, reader); err != nil {
-			return false, fmt.Errorf("%w: %w", ErrPullFailed, err)
-		}
+	tracker := newPullProgressTracker(progress)
+	if err := tracker.Track(reader); err != nil {
+		return false, wrapPullError(err)
 	}
 
 	pulledInspect, err := a.namespace.client.ImageInspect(ctx, a.Settings.Image)

--- a/internal/docker/application.go
+++ b/internal/docker/application.go
@@ -38,7 +38,9 @@ var (
 		msg:         "verification failed",
 		description: "The application couldn't be verified. Please check that you have a valid DNS record set up.",
 	}
-	ErrUnpauseFailed = errors.New("failed to unpause container after backup")
+	ErrUnpauseFailed                   = errors.New("failed to unpause container after backup")
+	ErrRegistryPasswordWithoutUsername = errors.New("registry password requires a username")
+	ErrRegistryUsernameWithoutPassword = errors.New("registry username requires a password")
 )
 
 const (
@@ -291,7 +293,7 @@ func (a *Application) saveOperationResult(ctx context.Context, record func(*Stat
 }
 
 func (a *Application) pullImage(ctx context.Context, progress DeployProgressCallback) (bool, error) {
-	opts := client.ImagePullOptions{RegistryAuth: registryAuthFor(a.Settings.Image)}
+	opts := client.ImagePullOptions{RegistryAuth: registryAuthFor(a.Settings)}
 	reader, err := a.namespace.client.ImagePull(ctx, a.Settings.Image, opts)
 	if err != nil {
 		return false, fmt.Errorf("%w: %w", ErrPullFailed, err)

--- a/internal/docker/application_settings.go
+++ b/internal/docker/application_settings.go
@@ -75,6 +75,16 @@ func (s SMTPSettings) BuildEnv() []string {
 	}
 }
 
+type RegistrySettings struct {
+	Image    string `json:"image,omitempty"`
+	Username string `json:"username,omitempty"`
+	Password string `json:"password,omitempty"`
+}
+
+func (r RegistrySettings) Empty() bool {
+	return r == RegistrySettings{}
+}
+
 type ContainerResources struct {
 	CPUs     int `json:"cpus,omitempty"`
 	MemoryMB int `json:"memoryMB,omitempty"`
@@ -96,6 +106,7 @@ type ApplicationSettings struct {
 	AutoUpdate bool               `json:"autoUpdate"`
 	Backup     BackupSettings     `json:"backup"`
 	Keys       Keys               `json:"keys"`
+	Registry   RegistrySettings   `json:"registry"`
 }
 
 func UnmarshalApplicationSettings(s string) (ApplicationSettings, error) {
@@ -115,6 +126,12 @@ func (s ApplicationSettings) Validate() error {
 	}
 	if s.Backup.AutoBackup && s.Backup.Path == "" {
 		return ErrAutoBackupWithoutPath
+	}
+	if s.Registry.Password != "" && s.Registry.Username == "" {
+		return ErrRegistryPasswordWithoutUsername
+	}
+	if s.Registry.Username != "" && s.Registry.Password == "" {
+		return ErrRegistryUsernameWithoutPassword
 	}
 	return nil
 }
@@ -140,6 +157,9 @@ func (s ApplicationSettings) Equal(other ApplicationSettings) bool {
 		return false
 	}
 	if s.Keys != other.Keys {
+		return false
+	}
+	if s.Registry != other.Registry {
 		return false
 	}
 	if len(s.EnvVars) != len(other.EnvVars) {

--- a/internal/docker/application_settings.go
+++ b/internal/docker/application_settings.go
@@ -76,7 +76,7 @@ func (s SMTPSettings) BuildEnv() []string {
 }
 
 type RegistrySettings struct {
-	Image    string `json:"image,omitempty"`
+	Host     string `json:"host,omitempty"`
 	Username string `json:"username,omitempty"`
 	Password string `json:"password,omitempty"`
 }

--- a/internal/docker/application_settings_test.go
+++ b/internal/docker/application_settings_test.go
@@ -324,6 +324,70 @@ func TestEnvVarsEqualDiffers(t *testing.T) {
 	assert.False(t, base.Equal(none))
 }
 
+func TestRegistrySettingsValidate(t *testing.T) {
+	base := ApplicationSettings{Name: "app", Image: "img:latest"}
+
+	t.Run("empty registry settings", func(t *testing.T) {
+		assert.NoError(t, base.Validate())
+	})
+
+	t.Run("username and password pair", func(t *testing.T) {
+		s := base
+		s.Registry = RegistrySettings{Image: "img:latest", Username: "user", Password: "pass"}
+		assert.NoError(t, s.Validate())
+	})
+
+	t.Run("password without username", func(t *testing.T) {
+		s := base
+		s.Registry = RegistrySettings{Image: "img:latest", Password: "pass"}
+		assert.ErrorIs(t, s.Validate(), ErrRegistryPasswordWithoutUsername)
+	})
+
+	t.Run("username without password", func(t *testing.T) {
+		s := base
+		s.Registry = RegistrySettings{Image: "img:latest", Username: "user"}
+		assert.ErrorIs(t, s.Validate(), ErrRegistryUsernameWithoutPassword)
+	})
+}
+
+func TestRegistrySettingsEqualDiffers(t *testing.T) {
+	base := ApplicationSettings{Name: "app", Registry: RegistrySettings{Image: "img:v1", Username: "user", Password: "pass"}}
+
+	differentPassword := base
+	differentPassword.Registry.Password = "rotated"
+	assert.False(t, base.Equal(differentPassword))
+
+	differentScope := base
+	differentScope.Registry.Image = "img:v2"
+	assert.False(t, base.Equal(differentScope))
+
+	same := base
+	assert.True(t, base.Equal(same))
+}
+
+func TestRegistrySettingsMarshalRoundTrip(t *testing.T) {
+	original := ApplicationSettings{
+		Name:     "app",
+		Image:    "img:latest",
+		Registry: RegistrySettings{Image: "img:latest", Username: "user", Password: "pass"},
+	}
+	restored, err := UnmarshalApplicationSettings(original.Marshal())
+	require.NoError(t, err)
+	assert.Equal(t, original.Registry, restored.Registry)
+	assert.True(t, original.Equal(restored))
+}
+
+func TestBuildEnvExcludesRegistryCredentials(t *testing.T) {
+	settings := ApplicationSettings{
+		Registry: RegistrySettings{Image: "img:latest", Username: "registry-user", Password: "registry-pass"},
+	}
+
+	for _, e := range settings.BuildEnv() {
+		assert.NotContains(t, e, "registry-user")
+		assert.NotContains(t, e, "registry-pass")
+	}
+}
+
 func TestAutoUpdateAndBackupMarshalRoundTrip(t *testing.T) {
 	original := ApplicationSettings{
 		Name:       "app",

--- a/internal/docker/application_settings_test.go
+++ b/internal/docker/application_settings_test.go
@@ -333,32 +333,32 @@ func TestRegistrySettingsValidate(t *testing.T) {
 
 	t.Run("username and password pair", func(t *testing.T) {
 		s := base
-		s.Registry = RegistrySettings{Image: "img:latest", Username: "user", Password: "pass"}
+		s.Registry = RegistrySettings{Host: "docker.io", Username: "user", Password: "pass"}
 		assert.NoError(t, s.Validate())
 	})
 
 	t.Run("password without username", func(t *testing.T) {
 		s := base
-		s.Registry = RegistrySettings{Image: "img:latest", Password: "pass"}
+		s.Registry = RegistrySettings{Host: "docker.io", Password: "pass"}
 		assert.ErrorIs(t, s.Validate(), ErrRegistryPasswordWithoutUsername)
 	})
 
 	t.Run("username without password", func(t *testing.T) {
 		s := base
-		s.Registry = RegistrySettings{Image: "img:latest", Username: "user"}
+		s.Registry = RegistrySettings{Host: "docker.io", Username: "user"}
 		assert.ErrorIs(t, s.Validate(), ErrRegistryUsernameWithoutPassword)
 	})
 }
 
 func TestRegistrySettingsEqualDiffers(t *testing.T) {
-	base := ApplicationSettings{Name: "app", Registry: RegistrySettings{Image: "img:v1", Username: "user", Password: "pass"}}
+	base := ApplicationSettings{Name: "app", Registry: RegistrySettings{Host: "docker.io", Username: "user", Password: "pass"}}
 
 	differentPassword := base
 	differentPassword.Registry.Password = "rotated"
 	assert.False(t, base.Equal(differentPassword))
 
 	differentScope := base
-	differentScope.Registry.Image = "img:v2"
+	differentScope.Registry.Host = "ghcr.io"
 	assert.False(t, base.Equal(differentScope))
 
 	same := base
@@ -369,7 +369,7 @@ func TestRegistrySettingsMarshalRoundTrip(t *testing.T) {
 	original := ApplicationSettings{
 		Name:     "app",
 		Image:    "img:latest",
-		Registry: RegistrySettings{Image: "img:latest", Username: "user", Password: "pass"},
+		Registry: RegistrySettings{Host: "docker.io", Username: "user", Password: "pass"},
 	}
 	restored, err := UnmarshalApplicationSettings(original.Marshal())
 	require.NoError(t, err)
@@ -379,7 +379,7 @@ func TestRegistrySettingsMarshalRoundTrip(t *testing.T) {
 
 func TestBuildEnvExcludesRegistryCredentials(t *testing.T) {
 	settings := ApplicationSettings{
-		Registry: RegistrySettings{Image: "img:latest", Username: "registry-user", Password: "registry-pass"},
+		Registry: RegistrySettings{Host: "docker.io", Username: "registry-user", Password: "registry-pass"},
 	}
 
 	for _, e := range settings.BuildEnv() {

--- a/internal/docker/errors.go
+++ b/internal/docker/errors.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/containerd/errdefs"
 	"github.com/moby/moby/client"
 )
 
@@ -50,6 +51,39 @@ func (e *describedError) Error() string       { return e.msg }
 func (e *describedError) Description() string { return e.description }
 
 // Helpers
+
+func wrapPullError(err error) error {
+	if pullErrorMayNeedAuth(err) {
+		return fmt.Errorf("%w: %w: %w", ErrPullMaybeUnauthorized, ErrPullFailed, err)
+	}
+	return fmt.Errorf("%w: %w", ErrPullFailed, err)
+}
+
+// pullErrorMayNeedAuth reports whether a pull failure looks like a missing or
+// unauthorized image. Registries conflate the two cases (some return 404 for
+// private images to hide their existence), so this is deliberately broad.
+func pullErrorMayNeedAuth(err error) bool {
+	if errdefs.IsUnauthorized(err) || errdefs.IsPermissionDenied(err) || errdefs.IsNotFound(err) {
+		return true
+	}
+	msg := strings.ToLower(err.Error())
+	for _, fragment := range []string{
+		"unauthorized",
+		"authentication required",
+		"denied",
+		"no basic auth credentials",
+		"forbidden",
+		"not found",
+		"manifest unknown",
+		"name unknown",
+		"repository does not exist",
+	} {
+		if strings.Contains(msg, fragment) {
+			return true
+		}
+	}
+	return false
+}
 
 func isPortConflict(err error) bool {
 	if err == nil {

--- a/internal/docker/errors_test.go
+++ b/internal/docker/errors_test.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/containerd/errdefs"
 	"github.com/moby/moby/client"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -34,6 +35,36 @@ func TestErrorMessage(t *testing.T) {
 	t.Run("returns Error for plain error", func(t *testing.T) {
 		err := errors.New("something broke")
 		assert.Equal(t, "something broke", ErrorMessage(err))
+	})
+}
+
+func TestWrapPullError(t *testing.T) {
+	authLike := func(t *testing.T, err error) {
+		t.Helper()
+		wrapped := wrapPullError(err)
+		assert.ErrorIs(t, wrapped, ErrPullMaybeUnauthorized)
+		assert.ErrorIs(t, wrapped, ErrPullFailed)
+		assert.Equal(t, ErrPullMaybeUnauthorized.Description(), ErrorMessage(wrapped))
+	}
+
+	t.Run("registry stream messages", func(t *testing.T) {
+		authLike(t, errors.New("unauthorized: authentication required"))
+		authLike(t, errors.New("pull access denied for private/app, repository does not exist or may require 'docker login'"))
+		authLike(t, errors.New("no basic auth credentials"))
+		authLike(t, errors.New("manifest unknown: manifest unknown"))
+	})
+
+	t.Run("typed daemon errors", func(t *testing.T) {
+		authLike(t, errdefs.ErrUnauthenticated)
+		authLike(t, errdefs.ErrPermissionDenied)
+		authLike(t, errdefs.ErrNotFound)
+	})
+
+	t.Run("other errors stay generic", func(t *testing.T) {
+		wrapped := wrapPullError(errors.New("dial tcp: connection refused"))
+		assert.ErrorIs(t, wrapped, ErrPullFailed)
+		assert.NotErrorIs(t, wrapped, ErrPullMaybeUnauthorized)
+		assert.Equal(t, ErrPullFailed.Description(), ErrorMessage(wrapped))
 	})
 }
 

--- a/internal/docker/progress.go
+++ b/internal/docker/progress.go
@@ -60,6 +60,10 @@ func (t *pullProgressTracker) Track(reader io.Reader) error {
 			return err
 		}
 
+		if msg.Error != nil {
+			return errors.New(msg.Error.Message)
+		}
+
 		t.processMessage(msg)
 	}
 
@@ -115,6 +119,9 @@ func (t *pullProgressTracker) reportProgress() {
 }
 
 func (t *pullProgressTracker) report(percentage int) {
+	if t.callback == nil {
+		return
+	}
 	t.callback(DeployProgress{
 		Stage:      DeployStageDownloading,
 		Percentage: percentage,

--- a/internal/docker/progress_test.go
+++ b/internal/docker/progress_test.go
@@ -61,6 +61,17 @@ func TestPullProgressTrackerWithCachedLayers(t *testing.T) {
 	assert.Equal(t, 100, lastUpdate.Percentage)
 }
 
+func TestPullProgressTrackerReturnsStreamError(t *testing.T) {
+	events := `{"status":"Pulling from private/app","id":"latest"}
+{"errorDetail":{"message":"unauthorized: authentication required"},"error":"unauthorized: authentication required"}
+`
+
+	tracker := newPullProgressTracker(nil)
+	err := tracker.Track(strings.NewReader(events))
+
+	assert.EqualError(t, err, "unauthorized: authentication required")
+}
+
 // Helpers
 
 func assertNeverDecreases(t *testing.T, updates []DeployProgress) {

--- a/internal/docker/registry_auth.go
+++ b/internal/docker/registry_auth.go
@@ -8,10 +8,20 @@ import (
 	"github.com/google/go-containerregistry/pkg/name"
 )
 
+// RegistryHost returns the registry host an image ref points at,
+// such as "ghcr.io" or "index.docker.io".
+func RegistryHost(imageRef string) (string, error) {
+	ref, err := name.ParseReference(imageRef)
+	if err != nil {
+		return "", err
+	}
+	return ref.Context().RegistryStr(), nil
+}
+
 // registryAuthFor returns a base64-encoded JSON auth string for pulling the
 // application's image, suitable for use in ImagePullOptions.RegistryAuth.
 // Credentials from the application settings are used when they are scoped to
-// the image's repository; otherwise the docker keychain is consulted.
+// the image's registry host; otherwise the docker keychain is consulted.
 // Returns "" on any error or missing credentials, falling back to anonymous access.
 func registryAuthFor(settings ApplicationSettings) string {
 	if auth := credentialAuth(settings.Registry, settings.Image); auth != "" {
@@ -23,7 +33,8 @@ func registryAuthFor(settings ApplicationSettings) string {
 // Helpers
 
 func credentialAuth(registry RegistrySettings, imageName string) string {
-	if registry.Empty() || !sameRepository(registry.Image, imageName) {
+	host, err := RegistryHost(imageName)
+	if err != nil || registry.Empty() || registry.Host != host {
 		return ""
 	}
 	return encodeAuthConfig(authn.AuthConfig{
@@ -46,20 +57,6 @@ func keychainAuth(imageName string) string {
 		return ""
 	}
 	return encodeAuthConfig(*cfg)
-}
-
-// sameRepository reports whether two image refs point at the same repository,
-// ignoring tags and digests. Unparsable refs never match.
-func sameRepository(a, b string) bool {
-	refA, err := name.ParseReference(a)
-	if err != nil {
-		return false
-	}
-	refB, err := name.ParseReference(b)
-	if err != nil {
-		return false
-	}
-	return refA.Context().Name() == refB.Context().Name()
 }
 
 func encodeAuthConfig(cfg authn.AuthConfig) string {

--- a/internal/docker/registry_auth.go
+++ b/internal/docker/registry_auth.go
@@ -8,10 +8,31 @@ import (
 	"github.com/google/go-containerregistry/pkg/name"
 )
 
-// registryAuthFor returns a base64-encoded JSON auth string for the registry
-// that hosts the given image, suitable for use in image.PullOptions.RegistryAuth.
+// registryAuthFor returns a base64-encoded JSON auth string for pulling the
+// application's image, suitable for use in ImagePullOptions.RegistryAuth.
+// Credentials from the application settings are used when they are scoped to
+// the image's repository; otherwise the docker keychain is consulted.
 // Returns "" on any error or missing credentials, falling back to anonymous access.
-func registryAuthFor(imageName string) string {
+func registryAuthFor(settings ApplicationSettings) string {
+	if auth := credentialAuth(settings.Registry, settings.Image); auth != "" {
+		return auth
+	}
+	return keychainAuth(settings.Image)
+}
+
+// Helpers
+
+func credentialAuth(registry RegistrySettings, imageName string) string {
+	if registry.Empty() || !sameRepository(registry.Image, imageName) {
+		return ""
+	}
+	return encodeAuthConfig(authn.AuthConfig{
+		Username: registry.Username,
+		Password: registry.Password,
+	})
+}
+
+func keychainAuth(imageName string) string {
 	ref, err := name.ParseReference(imageName)
 	if err != nil {
 		return ""
@@ -24,6 +45,24 @@ func registryAuthFor(imageName string) string {
 	if err != nil {
 		return ""
 	}
+	return encodeAuthConfig(*cfg)
+}
+
+// sameRepository reports whether two image refs point at the same repository,
+// ignoring tags and digests. Unparsable refs never match.
+func sameRepository(a, b string) bool {
+	refA, err := name.ParseReference(a)
+	if err != nil {
+		return false
+	}
+	refB, err := name.ParseReference(b)
+	if err != nil {
+		return false
+	}
+	return refA.Context().Name() == refB.Context().Name()
+}
+
+func encodeAuthConfig(cfg authn.AuthConfig) string {
 	data, err := json.Marshal(cfg)
 	if err != nil {
 		return ""

--- a/internal/docker/registry_auth_test.go
+++ b/internal/docker/registry_auth_test.go
@@ -129,7 +129,7 @@ func TestRegistryAuthForScopedCredentials(t *testing.T) {
 		writeDockerConfig(t, dir, map[string]string{"ghcr.io": encoded}, nil, "")
 
 		token := registryAuthFor(settings("ghcr.io/basecamp/once:main", RegistrySettings{
-			Image:    "ghcr.io/basecamp/once:v1",
+			Host:     "ghcr.io",
 			Username: "scoped-user",
 			Password: "scoped-pass",
 		}))
@@ -139,13 +139,27 @@ func TestRegistryAuthForScopedCredentials(t *testing.T) {
 		assert.Equal(t, "scoped-pass", ac.Password)
 	})
 
-	t.Run("credentials for a different repository fall back to the keychain", func(t *testing.T) {
+	t.Run("credentials apply to any image on the same host", func(t *testing.T) {
+		isolateDockerConfig(t)
+
+		token := registryAuthFor(settings("ghcr.io/other/app:v2", RegistrySettings{
+			Host:     "ghcr.io",
+			Username: "scoped-user",
+			Password: "scoped-pass",
+		}))
+		require.NotEmpty(t, token)
+		ac := decodeAuthToken(t, token)
+		assert.Equal(t, "scoped-user", ac.Username)
+		assert.Equal(t, "scoped-pass", ac.Password)
+	})
+
+	t.Run("credentials for a different host fall back to the keychain", func(t *testing.T) {
 		dir := isolateDockerConfig(t)
 		encoded := base64.StdEncoding.EncodeToString([]byte("keychain-user:keychain-pass"))
 		writeDockerConfig(t, dir, map[string]string{"ghcr.io": encoded}, nil, "")
 
 		token := registryAuthFor(settings("ghcr.io/basecamp/once:main", RegistrySettings{
-			Image:    "registry.example.com/other/app:v1",
+			Host:     "registry.example.com",
 			Username: "scoped-user",
 			Password: "scoped-pass",
 		}))
@@ -155,11 +169,11 @@ func TestRegistryAuthForScopedCredentials(t *testing.T) {
 		assert.Equal(t, "keychain-pass", ac.Password)
 	})
 
-	t.Run("credentials for a different repository with no keychain entry", func(t *testing.T) {
+	t.Run("credentials for a different host with no keychain entry", func(t *testing.T) {
 		isolateDockerConfig(t)
 
 		token := registryAuthFor(settings("ghcr.io/basecamp/once:main", RegistrySettings{
-			Image:    "registry.example.com/other/app:v1",
+			Host:     "registry.example.com",
 			Username: "scoped-user",
 			Password: "scoped-pass",
 		}))
@@ -167,22 +181,21 @@ func TestRegistryAuthForScopedCredentials(t *testing.T) {
 	})
 }
 
-func TestSameRepository(t *testing.T) {
-	tests := []struct {
-		a, b string
-		want bool
-	}{
-		{"ghcr.io/basecamp/once:v1", "ghcr.io/basecamp/once:v2", true},
-		{"ghcr.io/basecamp/once:v1", "ghcr.io/basecamp/once@sha256:1111111111111111111111111111111111111111111111111111111111111111", true},
-		{"nginx", "docker.io/library/nginx:latest", true},
-		{"ghcr.io/basecamp/once:v1", "registry.example.com/basecamp/once:v1", false},
-		{"ghcr.io/basecamp/once:v1", "ghcr.io/basecamp/other:v1", false},
-		{":::bad", "ghcr.io/basecamp/once:v1", false},
-		{"ghcr.io/basecamp/once:v1", ":::bad", false},
-	}
-	for _, tt := range tests {
-		assert.Equal(t, tt.want, sameRepository(tt.a, tt.b), "%s vs %s", tt.a, tt.b)
-	}
+func TestRegistryHost(t *testing.T) {
+	host, err := RegistryHost("ghcr.io/basecamp/once:v1")
+	require.NoError(t, err)
+	assert.Equal(t, "ghcr.io", host)
+
+	host, err = RegistryHost("nginx")
+	require.NoError(t, err)
+	assert.Equal(t, "index.docker.io", host)
+
+	host, err = RegistryHost("registry.example.com:5000/app@sha256:1111111111111111111111111111111111111111111111111111111111111111")
+	require.NoError(t, err)
+	assert.Equal(t, "registry.example.com:5000", host)
+
+	_, err = RegistryHost(":::bad")
+	assert.Error(t, err)
 }
 
 // Helpers

--- a/internal/docker/registry_auth_test.go
+++ b/internal/docker/registry_auth_test.go
@@ -15,12 +15,12 @@ import (
 func TestRegistryAuthFor(t *testing.T) {
 	t.Run("invalid image string", func(t *testing.T) {
 		isolateDockerConfig(t)
-		assert.Equal(t, "", registryAuthFor(":::bad"))
+		assert.Equal(t, "", authForImage(":::bad"))
 	})
 
 	t.Run("no docker config present", func(t *testing.T) {
 		isolateDockerConfig(t)
-		assert.Equal(t, "", registryAuthFor("ghcr.io/basecamp/once:main"))
+		assert.Equal(t, "", authForImage("ghcr.io/basecamp/once:main"))
 	})
 
 	t.Run("reads config from DOCKER_CONFIG directory", func(t *testing.T) {
@@ -28,7 +28,7 @@ func TestRegistryAuthFor(t *testing.T) {
 		encoded := base64.StdEncoding.EncodeToString([]byte("myuser:mypass"))
 		writeDockerConfig(t, dir, map[string]string{"ghcr.io": encoded}, nil, "")
 
-		token := registryAuthFor("ghcr.io/basecamp/once:main")
+		token := authForImage("ghcr.io/basecamp/once:main")
 		require.NotEmpty(t, token)
 		ac := decodeAuthToken(t, token)
 		assert.Equal(t, "myuser", ac.Username)
@@ -39,7 +39,7 @@ func TestRegistryAuthFor(t *testing.T) {
 		dir := isolateDockerConfig(t)
 		require.NoError(t, os.WriteFile(filepath.Join(dir, "config.json"), []byte("{not json}"), 0600))
 
-		assert.Equal(t, "", registryAuthFor("ghcr.io/basecamp/once:main"))
+		assert.Equal(t, "", authForImage("ghcr.io/basecamp/once:main"))
 	})
 
 	t.Run("config has credHelpers for host", func(t *testing.T) {
@@ -47,7 +47,7 @@ func TestRegistryAuthFor(t *testing.T) {
 		installFakeCredHelper(t, "myhelper", credHelperScript("helper-user", "helper-pass"))
 		writeDockerConfig(t, dir, nil, map[string]string{"ghcr.io": "myhelper"}, "")
 
-		token := registryAuthFor("ghcr.io/basecamp/once:main")
+		token := authForImage("ghcr.io/basecamp/once:main")
 		require.NotEmpty(t, token)
 		ac := decodeAuthToken(t, token)
 		assert.Equal(t, "helper-user", ac.Username)
@@ -59,7 +59,7 @@ func TestRegistryAuthFor(t *testing.T) {
 		installFakeCredHelper(t, "mystore", credHelperScript("store-user", "store-pass"))
 		writeDockerConfig(t, dir, nil, nil, "mystore")
 
-		token := registryAuthFor("ghcr.io/basecamp/once:main")
+		token := authForImage("ghcr.io/basecamp/once:main")
 		require.NotEmpty(t, token)
 		ac := decodeAuthToken(t, token)
 		assert.Equal(t, "store-user", ac.Username)
@@ -82,7 +82,7 @@ echo '{"ServerURL":"","Username":"store-user","Secret":"store-pass"}'
 `)
 		writeDockerConfig(t, dir, nil, map[string]string{"ghcr.io": "specific-helper"}, "global-store")
 
-		token := registryAuthFor("ghcr.io/basecamp/once:main")
+		token := authForImage("ghcr.io/basecamp/once:main")
 		require.NotEmpty(t, token)
 		ac := decodeAuthToken(t, token)
 		assert.Equal(t, "helper-user", ac.Username)
@@ -94,7 +94,7 @@ echo '{"ServerURL":"","Username":"store-user","Secret":"store-pass"}'
 		encoded := base64.StdEncoding.EncodeToString([]byte("inline-user:inline-pass"))
 		writeDockerConfig(t, dir, map[string]string{"ghcr.io": encoded}, nil, "")
 
-		token := registryAuthFor("ghcr.io/basecamp/once:main")
+		token := authForImage("ghcr.io/basecamp/once:main")
 		require.NotEmpty(t, token)
 		ac := decodeAuthToken(t, token)
 		assert.Equal(t, "inline-user", ac.Username)
@@ -106,7 +106,7 @@ echo '{"ServerURL":"","Username":"store-user","Secret":"store-pass"}'
 		installFakeCredHelper(t, "failing-helper", "#!/bin/sh\nexit 1\n")
 		writeDockerConfig(t, dir, nil, map[string]string{"ghcr.io": "failing-helper"}, "")
 
-		assert.Equal(t, "", registryAuthFor("ghcr.io/basecamp/once:main"))
+		assert.Equal(t, "", authForImage("ghcr.io/basecamp/once:main"))
 	})
 
 	t.Run("no matching entry for host", func(t *testing.T) {
@@ -114,11 +114,82 @@ echo '{"ServerURL":"","Username":"store-user","Secret":"store-pass"}'
 		encoded := base64.StdEncoding.EncodeToString([]byte("user:pass"))
 		writeDockerConfig(t, dir, map[string]string{"docker.io": encoded}, nil, "")
 
-		assert.Equal(t, "", registryAuthFor("ghcr.io/basecamp/once:main"))
+		assert.Equal(t, "", authForImage("ghcr.io/basecamp/once:main"))
 	})
 }
 
+func TestRegistryAuthForScopedCredentials(t *testing.T) {
+	settings := func(image string, registry RegistrySettings) ApplicationSettings {
+		return ApplicationSettings{Image: image, Registry: registry}
+	}
+
+	t.Run("scoped credentials win over the keychain", func(t *testing.T) {
+		dir := isolateDockerConfig(t)
+		encoded := base64.StdEncoding.EncodeToString([]byte("keychain-user:keychain-pass"))
+		writeDockerConfig(t, dir, map[string]string{"ghcr.io": encoded}, nil, "")
+
+		token := registryAuthFor(settings("ghcr.io/basecamp/once:main", RegistrySettings{
+			Image:    "ghcr.io/basecamp/once:v1",
+			Username: "scoped-user",
+			Password: "scoped-pass",
+		}))
+		require.NotEmpty(t, token)
+		ac := decodeAuthToken(t, token)
+		assert.Equal(t, "scoped-user", ac.Username)
+		assert.Equal(t, "scoped-pass", ac.Password)
+	})
+
+	t.Run("credentials for a different repository fall back to the keychain", func(t *testing.T) {
+		dir := isolateDockerConfig(t)
+		encoded := base64.StdEncoding.EncodeToString([]byte("keychain-user:keychain-pass"))
+		writeDockerConfig(t, dir, map[string]string{"ghcr.io": encoded}, nil, "")
+
+		token := registryAuthFor(settings("ghcr.io/basecamp/once:main", RegistrySettings{
+			Image:    "registry.example.com/other/app:v1",
+			Username: "scoped-user",
+			Password: "scoped-pass",
+		}))
+		require.NotEmpty(t, token)
+		ac := decodeAuthToken(t, token)
+		assert.Equal(t, "keychain-user", ac.Username)
+		assert.Equal(t, "keychain-pass", ac.Password)
+	})
+
+	t.Run("credentials for a different repository with no keychain entry", func(t *testing.T) {
+		isolateDockerConfig(t)
+
+		token := registryAuthFor(settings("ghcr.io/basecamp/once:main", RegistrySettings{
+			Image:    "registry.example.com/other/app:v1",
+			Username: "scoped-user",
+			Password: "scoped-pass",
+		}))
+		assert.Equal(t, "", token)
+	})
+}
+
+func TestSameRepository(t *testing.T) {
+	tests := []struct {
+		a, b string
+		want bool
+	}{
+		{"ghcr.io/basecamp/once:v1", "ghcr.io/basecamp/once:v2", true},
+		{"ghcr.io/basecamp/once:v1", "ghcr.io/basecamp/once@sha256:1111111111111111111111111111111111111111111111111111111111111111", true},
+		{"nginx", "docker.io/library/nginx:latest", true},
+		{"ghcr.io/basecamp/once:v1", "registry.example.com/basecamp/once:v1", false},
+		{"ghcr.io/basecamp/once:v1", "ghcr.io/basecamp/other:v1", false},
+		{":::bad", "ghcr.io/basecamp/once:v1", false},
+		{"ghcr.io/basecamp/once:v1", ":::bad", false},
+	}
+	for _, tt := range tests {
+		assert.Equal(t, tt.want, sameRepository(tt.a, tt.b), "%s vs %s", tt.a, tt.b)
+	}
+}
+
 // Helpers
+
+func authForImage(image string) string {
+	return registryAuthFor(ApplicationSettings{Image: image})
+}
 
 // isolateDockerConfig sets DOCKER_CONFIG to a fresh temp dir so tests don't
 // touch the real Docker config. Returns the temp dir path.

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -50,6 +50,7 @@ type SettingsSectionType int
 
 const (
 	SettingsSectionApplication SettingsSectionType = iota
+	SettingsSectionRegistry
 	SettingsSectionEmail
 	SettingsSectionEnvironment
 	SettingsSectionResources

--- a/internal/ui/install.go
+++ b/internal/ui/install.go
@@ -37,22 +37,23 @@ type InstallFormSubmitMsg struct {
 }
 
 type Install struct {
-	namespace     *docker.Namespace
-	width, height int
-	help          Help
-	state         installState
-	appList       InstallAppList
-	imageForm     InstallImageForm
-	hostnameForm  InstallHostnameForm
-	activity      *InstallActivity
-	popupHelp     *PopupHelp
-	starfield     *Starfield
-	logo          *Logo
-	err           error
-	cliMode       bool
-	customImage   bool
-	installFlag   string
-	registry      docker.RegistrySettings
+	namespace      *docker.Namespace
+	width, height  int
+	help           Help
+	state          installState
+	appList        InstallAppList
+	imageForm      InstallImageForm
+	hostnameForm   InstallHostnameForm
+	activity       *InstallActivity
+	popupHelp      *PopupHelp
+	starfield      *Starfield
+	logo           *Logo
+	err            error
+	cliMode        bool
+	customImage    bool
+	customImageRef string
+	installFlag    string
+	registry       docker.RegistrySettings
 }
 
 func NewInstall(ns *docker.Namespace, imageRef string) Install {
@@ -189,6 +190,7 @@ func (m Install) Update(msg tea.Msg) (Component, tea.Cmd) {
 		}
 		m.hostnameForm = NewInstallHostnameForm(msg.ImageRef, "")
 		m.customImage = true
+		m.customImageRef = msg.ImageRef
 		m.registry = docker.RegistrySettings{}
 		if msg.RegistryUsername != "" || msg.RegistryPassword != "" {
 			host, _ := docker.RegistryHost(msg.ImageRef)
@@ -232,6 +234,10 @@ func (m Install) Update(msg tea.Msg) (Component, tea.Cmd) {
 		m.err = msg.Err
 		if errors.Is(msg.Err, docker.ErrPullFailed) {
 			m.state = m.imageErrorState()
+			if m.state == installStateImageForm && errors.Is(msg.Err, docker.ErrPullMaybeUnauthorized) && !m.imageForm.ShowsCredentials() {
+				m.imageForm = NewInstallImageFormWithCredentials(m.customImageRef)
+				return m, m.initScreenWithSize()
+			}
 		} else {
 			m.state = installStateHostname
 		}

--- a/internal/ui/install.go
+++ b/internal/ui/install.go
@@ -183,8 +183,9 @@ func (m Install) Update(msg tea.Msg) (Component, tea.Cmd) {
 		m.customImage = true
 		m.registry = docker.RegistrySettings{}
 		if msg.RegistryUsername != "" || msg.RegistryPassword != "" {
+			host, _ := docker.RegistryHost(msg.ImageRef)
 			m.registry = docker.RegistrySettings{
-				Image:    msg.ImageRef,
+				Host:     host,
 				Username: msg.RegistryUsername,
 				Password: msg.RegistryPassword,
 			}

--- a/internal/ui/install.go
+++ b/internal/ui/install.go
@@ -52,6 +52,7 @@ type Install struct {
 	cliMode       bool
 	customImage   bool
 	installFlag   string
+	registry      docker.RegistrySettings
 }
 
 func NewInstall(ns *docker.Namespace, imageRef string) Install {
@@ -168,6 +169,7 @@ func (m Install) Update(msg tea.Msg) (Component, tea.Cmd) {
 	case InstallAppSelectedMsg:
 		m.hostnameForm = NewInstallHostnameForm(msg.ImageRef, "")
 		m.customImage = false
+		m.registry = docker.RegistrySettings{}
 		m.state = installStateHostname
 		return m, m.initScreenWithSize()
 
@@ -179,6 +181,14 @@ func (m Install) Update(msg tea.Msg) (Component, tea.Cmd) {
 	case InstallImageSubmitMsg:
 		m.hostnameForm = NewInstallHostnameForm(msg.ImageRef, "")
 		m.customImage = true
+		m.registry = docker.RegistrySettings{}
+		if msg.RegistryUsername != "" || msg.RegistryPassword != "" {
+			m.registry = docker.RegistrySettings{
+				Image:    msg.ImageRef,
+				Username: msg.RegistryUsername,
+				Password: msg.RegistryPassword,
+			}
+		}
 		m.state = installStateHostname
 		return m, m.initScreenWithSize()
 
@@ -203,7 +213,7 @@ func (m Install) Update(msg tea.Msg) (Component, tea.Cmd) {
 			return m, nil
 		}
 		m.state = installStateActivity
-		m.activity = NewInstallActivity(m.namespace, msg.ImageRef, msg.Hostname)
+		m.activity = NewInstallActivity(m.namespace, msg.ImageRef, msg.Hostname, m.registry)
 		m.activity.Update(tea.WindowSizeMsg{Width: m.width, Height: m.height})
 		return m, m.activity.Init()
 

--- a/internal/ui/install.go
+++ b/internal/ui/install.go
@@ -179,6 +179,14 @@ func (m Install) Update(msg tea.Msg) (Component, tea.Cmd) {
 		return m, m.initScreenWithSize()
 
 	case InstallImageSubmitMsg:
+		if msg.RegistryUsername != "" && msg.RegistryPassword == "" {
+			m.err = docker.ErrRegistryUsernameWithoutPassword
+			return m, nil
+		}
+		if msg.RegistryPassword != "" && msg.RegistryUsername == "" {
+			m.err = docker.ErrRegistryPasswordWithoutUsername
+			return m, nil
+		}
 		m.hostnameForm = NewInstallHostnameForm(msg.ImageRef, "")
 		m.customImage = true
 		m.registry = docker.RegistrySettings{}

--- a/internal/ui/install_activity.go
+++ b/internal/ui/install_activity.go
@@ -42,6 +42,7 @@ type InstallActivity struct {
 	namespace     *docker.Namespace
 	imageRef      string
 	hostname      string
+	registry      docker.RegistrySettings
 	width, height int
 	stage         installStage
 	percentage    int
@@ -52,12 +53,13 @@ type InstallActivity struct {
 	cancel        context.CancelFunc
 }
 
-func NewInstallActivity(ns *docker.Namespace, imageRef, hostname string) *InstallActivity {
+func NewInstallActivity(ns *docker.Namespace, imageRef, hostname string, registry docker.RegistrySettings) *InstallActivity {
 	ctx, cancel := context.WithCancel(context.Background())
 	return &InstallActivity{
 		namespace:    ns,
 		imageRef:     imageRef,
 		hostname:     hostname,
+		registry:     registry,
 		stage:        stagePreparing,
 		progress:     NewProgress(0, Colors.Primary),
 		progressChan: make(chan installProgressMsg, 10),
@@ -180,6 +182,7 @@ func (m *InstallActivity) runInstall(ctx context.Context) {
 		Image:      m.imageRef,
 		Host:       hostname,
 		AutoUpdate: true,
+		Registry:   m.registry,
 	})
 
 	progress := func(p docker.DeployProgress) {

--- a/internal/ui/install_image_form.go
+++ b/internal/ui/install_image_form.go
@@ -4,7 +4,17 @@ import (
 	tea "charm.land/bubbletea/v2"
 )
 
-type InstallImageSubmitMsg struct{ ImageRef string }
+const (
+	installImageField = iota
+	installRegistryUsernameField
+	installRegistryPasswordField
+)
+
+type InstallImageSubmitMsg struct {
+	ImageRef         string
+	RegistryUsername string
+	RegistryPassword string
+}
 type InstallImageBackMsg struct{}
 
 type InstallImageForm struct {
@@ -12,20 +22,34 @@ type InstallImageForm struct {
 }
 
 func NewInstallImageForm() InstallImageForm {
+	usernameField := NewTextField("(optional)")
+	passwordField := NewTextField("(optional)")
+	passwordField.SetEchoPassword()
+
 	m := InstallImageForm{
-		form: NewForm("Next", FormItem{
-			Label:    "Image",
-			Field:    NewTextField("user/repo:tag"),
-			Required: true,
-		}),
+		form: NewForm("Next",
+			FormItem{
+				Label:    "Image",
+				Field:    NewTextField("user/repo:tag"),
+				Required: true,
+			},
+			FormItem{Label: "Registry Username", Field: usernameField},
+			FormItem{Label: "Registry Password", Field: passwordField},
+		),
 	}
 
 	m.form.OnSubmit(func(f *Form) tea.Cmd {
-		ref := f.TextField(0).Value()
+		ref := f.TextField(installImageField).Value()
 		if expanded, ok := expandAlias(ref); ok {
 			ref = expanded
 		}
-		return func() tea.Msg { return InstallImageSubmitMsg{ImageRef: ref} }
+		return func() tea.Msg {
+			return InstallImageSubmitMsg{
+				ImageRef:         ref,
+				RegistryUsername: f.TextField(installRegistryUsernameField).Value(),
+				RegistryPassword: f.TextField(installRegistryPasswordField).Value(),
+			}
+		}
 	})
 	m.form.OnCancel(func(f *Form) tea.Cmd {
 		return func() tea.Msg { return InstallImageBackMsg{} }

--- a/internal/ui/install_image_form.go
+++ b/internal/ui/install_image_form.go
@@ -4,11 +4,7 @@ import (
 	tea "charm.land/bubbletea/v2"
 )
 
-const (
-	installImageField = iota
-	installRegistryUsernameField
-	installRegistryPasswordField
-)
+const installImageField = 0
 
 type InstallImageSubmitMsg struct {
 	ImageRef         string
@@ -18,44 +14,26 @@ type InstallImageSubmitMsg struct {
 type InstallImageBackMsg struct{}
 
 type InstallImageForm struct {
-	form Form
+	form            Form
+	showCredentials bool
 }
 
 func NewInstallImageForm() InstallImageForm {
-	usernameField := NewTextField("(optional)")
-	passwordField := NewTextField("(optional)")
-	passwordField.SetEchoPassword()
+	return newInstallImageForm(false, "")
+}
 
-	m := InstallImageForm{
-		form: NewForm("Next",
-			FormItem{
-				Label:    "Image",
-				Field:    NewTextField("user/repo:tag"),
-				Required: true,
-			},
-			FormItem{Label: "Registry Username", Field: usernameField},
-			FormItem{Label: "Registry Password", Field: passwordField},
-		),
-	}
+// NewInstallImageFormWithCredentials builds the form with the registry
+// username/password fields revealed, prefilled with the given image ref.
+func NewInstallImageFormWithCredentials(imageRef string) InstallImageForm {
+	return newInstallImageForm(true, imageRef)
+}
 
-	m.form.OnSubmit(func(f *Form) tea.Cmd {
-		ref := f.TextField(installImageField).Value()
-		if expanded, ok := expandAlias(ref); ok {
-			ref = expanded
-		}
-		return func() tea.Msg {
-			return InstallImageSubmitMsg{
-				ImageRef:         ref,
-				RegistryUsername: f.TextField(installRegistryUsernameField).Value(),
-				RegistryPassword: f.TextField(installRegistryPasswordField).Value(),
-			}
-		}
-	})
-	m.form.OnCancel(func(f *Form) tea.Cmd {
-		return func() tea.Msg { return InstallImageBackMsg{} }
-	})
+func (m InstallImageForm) ShowsCredentials() bool {
+	return m.showCredentials
+}
 
-	return m
+func (m InstallImageForm) ImageRef() string {
+	return m.form.TextField(installImageField).Value()
 }
 
 func (m InstallImageForm) Init() tea.Cmd {
@@ -70,4 +48,47 @@ func (m InstallImageForm) Update(msg tea.Msg) (InstallImageForm, tea.Cmd) {
 
 func (m InstallImageForm) View() string {
 	return m.form.View()
+}
+
+// Helpers
+
+func newInstallImageForm(showCredentials bool, imageRef string) InstallImageForm {
+	imageField := NewTextField("user/repo:tag")
+	imageField.SetValue(imageRef)
+
+	items := []FormItem{{Label: "Image", Field: imageField, Required: true}}
+
+	var usernameField, passwordField *TextField
+	if showCredentials {
+		usernameField = NewTextField("(optional)")
+		passwordField = NewTextField("(optional)")
+		passwordField.SetEchoPassword()
+		items = append(items,
+			FormItem{Label: "Registry Username", Field: usernameField},
+			FormItem{Label: "Registry Password", Field: passwordField},
+		)
+	}
+
+	m := InstallImageForm{
+		form:            NewForm("Next", items...),
+		showCredentials: showCredentials,
+	}
+
+	m.form.OnSubmit(func(f *Form) tea.Cmd {
+		ref := imageField.Value()
+		if expanded, ok := expandAlias(ref); ok {
+			ref = expanded
+		}
+		msg := InstallImageSubmitMsg{ImageRef: ref}
+		if showCredentials {
+			msg.RegistryUsername = usernameField.Value()
+			msg.RegistryPassword = passwordField.Value()
+		}
+		return func() tea.Msg { return msg }
+	})
+	m.form.OnCancel(func(f *Form) tea.Cmd {
+		return func() tea.Msg { return InstallImageBackMsg{} }
+	})
+
+	return m
 }

--- a/internal/ui/install_image_form_test.go
+++ b/internal/ui/install_image_form_test.go
@@ -7,11 +7,17 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestInstallImageForm_HidesCredentialFieldsByDefault(t *testing.T) {
+	form := NewInstallImageForm()
+	assert.False(t, form.ShowsCredentials())
+	assert.NotContains(t, form.View(), "Registry Username")
+}
+
 func TestInstallImageForm_SubmitWithAlias(t *testing.T) {
 	form := NewInstallImageForm()
 
 	imageFormTypeText(&form, "campfire")
-	imageFormTabTo(&form, 3) // past username and password to submit
+	imageFormTabTo(&form, 1) // to submit
 	form, cmd := form.Update(keyPressMsg("enter"))
 	require.NotNil(t, cmd)
 
@@ -27,7 +33,7 @@ func TestInstallImageForm_SubmitWithCustomImage(t *testing.T) {
 	form := NewInstallImageForm()
 
 	imageFormTypeText(&form, "ghcr.io/basecamp/once-campfire:latest")
-	imageFormTabTo(&form, 3)
+	imageFormTabTo(&form, 1)
 	form, cmd := form.Update(keyPressMsg("enter"))
 	require.NotNil(t, cmd)
 
@@ -38,10 +44,11 @@ func TestInstallImageForm_SubmitWithCustomImage(t *testing.T) {
 }
 
 func TestInstallImageForm_SubmitWithRegistryCredentials(t *testing.T) {
-	form := NewInstallImageForm()
+	form := NewInstallImageFormWithCredentials("registry.example.com/app:latest")
+	assert.True(t, form.ShowsCredentials())
+	assert.Equal(t, "registry.example.com/app:latest", form.ImageRef())
 
-	imageFormTypeText(&form, "registry.example.com/app:latest")
-	imageFormTabTo(&form, 1)
+	imageFormTabTo(&form, 1) // to username
 	imageFormTypeText(&form, "user")
 	imageFormTabTo(&form, 1)
 	imageFormTypeText(&form, "pass")
@@ -60,8 +67,8 @@ func TestInstallImageForm_SubmitWithRegistryCredentials(t *testing.T) {
 func TestInstallImageForm_Cancel(t *testing.T) {
 	form := NewInstallImageForm()
 
-	// Tab past the fields and submit button to cancel
-	imageFormTabTo(&form, 4)
+	// Tab past the field and submit button to cancel
+	imageFormTabTo(&form, 2)
 	form, cmd := form.Update(keyPressMsg("enter"))
 	require.NotNil(t, cmd)
 
@@ -74,7 +81,7 @@ func TestInstallImageForm_RequiresImage(t *testing.T) {
 	form := NewInstallImageForm()
 
 	// Tab to submit button, then press enter with empty image field
-	imageFormTabTo(&form, 3)
+	imageFormTabTo(&form, 1)
 	form, _ = form.Update(keyPressMsg("enter"))
 	assert.True(t, form.form.HasError())
 }

--- a/internal/ui/install_image_form_test.go
+++ b/internal/ui/install_image_form_test.go
@@ -11,7 +11,7 @@ func TestInstallImageForm_SubmitWithAlias(t *testing.T) {
 	form := NewInstallImageForm()
 
 	imageFormTypeText(&form, "campfire")
-	imageFormPressTab(&form)
+	imageFormTabTo(&form, 3) // past username and password to submit
 	form, cmd := form.Update(keyPressMsg("enter"))
 	require.NotNil(t, cmd)
 
@@ -19,13 +19,15 @@ func TestInstallImageForm_SubmitWithAlias(t *testing.T) {
 	submit, ok := msg.(InstallImageSubmitMsg)
 	require.True(t, ok, "expected InstallImageSubmitMsg, got %T", msg)
 	assert.Equal(t, "ghcr.io/basecamp/once-campfire", submit.ImageRef)
+	assert.Empty(t, submit.RegistryUsername)
+	assert.Empty(t, submit.RegistryPassword)
 }
 
 func TestInstallImageForm_SubmitWithCustomImage(t *testing.T) {
 	form := NewInstallImageForm()
 
 	imageFormTypeText(&form, "ghcr.io/basecamp/once-campfire:latest")
-	imageFormPressTab(&form)
+	imageFormTabTo(&form, 3)
 	form, cmd := form.Update(keyPressMsg("enter"))
 	require.NotNil(t, cmd)
 
@@ -35,12 +37,31 @@ func TestInstallImageForm_SubmitWithCustomImage(t *testing.T) {
 	assert.Equal(t, "ghcr.io/basecamp/once-campfire:latest", submit.ImageRef)
 }
 
+func TestInstallImageForm_SubmitWithRegistryCredentials(t *testing.T) {
+	form := NewInstallImageForm()
+
+	imageFormTypeText(&form, "registry.example.com/app:latest")
+	imageFormTabTo(&form, 1)
+	imageFormTypeText(&form, "user")
+	imageFormTabTo(&form, 1)
+	imageFormTypeText(&form, "pass")
+	imageFormTabTo(&form, 1)
+	form, cmd := form.Update(keyPressMsg("enter"))
+	require.NotNil(t, cmd)
+
+	msg := cmd()
+	submit, ok := msg.(InstallImageSubmitMsg)
+	require.True(t, ok, "expected InstallImageSubmitMsg, got %T", msg)
+	assert.Equal(t, "registry.example.com/app:latest", submit.ImageRef)
+	assert.Equal(t, "user", submit.RegistryUsername)
+	assert.Equal(t, "pass", submit.RegistryPassword)
+}
+
 func TestInstallImageForm_Cancel(t *testing.T) {
 	form := NewInstallImageForm()
 
-	// Tab to submit, tab to cancel
-	imageFormPressTab(&form)
-	imageFormPressTab(&form)
+	// Tab past the fields and submit button to cancel
+	imageFormTabTo(&form, 4)
 	form, cmd := form.Update(keyPressMsg("enter"))
 	require.NotNil(t, cmd)
 
@@ -52,8 +73,8 @@ func TestInstallImageForm_Cancel(t *testing.T) {
 func TestInstallImageForm_RequiresImage(t *testing.T) {
 	form := NewInstallImageForm()
 
-	// Tab to submit button, then press enter with empty field
-	imageFormPressTab(&form)
+	// Tab to submit button, then press enter with empty image field
+	imageFormTabTo(&form, 3)
 	form, _ = form.Update(keyPressMsg("enter"))
 	assert.True(t, form.form.HasError())
 }
@@ -66,6 +87,8 @@ func imageFormTypeText(form *InstallImageForm, text string) {
 	}
 }
 
-func imageFormPressTab(form *InstallImageForm) {
-	*form, _ = form.Update(keyPressMsg("tab"))
+func imageFormTabTo(form *InstallImageForm, presses int) {
+	for range presses {
+		*form, _ = form.Update(keyPressMsg("tab"))
+	}
 }

--- a/internal/ui/install_test.go
+++ b/internal/ui/install_test.go
@@ -55,7 +55,7 @@ func TestInstall_CustomImageWithRegistryCredentials(t *testing.T) {
 		RegistryPassword: "pass",
 	})
 
-	expected := docker.RegistrySettings{Image: "registry.example.com/app:latest", Username: "user", Password: "pass"}
+	expected := docker.RegistrySettings{Host: "registry.example.com", Username: "user", Password: "pass"}
 	assert.Equal(t, expected, m.registry)
 
 	m, _ = updateInstall(m, InstallFormSubmitMsg{ImageRef: "registry.example.com/app:latest", Hostname: "app.example.com"})

--- a/internal/ui/install_test.go
+++ b/internal/ui/install_test.go
@@ -44,6 +44,37 @@ func TestInstall_CustomImageFlow(t *testing.T) {
 	assert.Equal(t, installStateActivity, m.state)
 }
 
+func TestInstall_CustomImageWithRegistryCredentials(t *testing.T) {
+	m := newTestInstall()
+	m, _ = updateInstall(m, tea.WindowSizeMsg{Width: 80, Height: 24})
+
+	m, _ = updateInstall(m, InstallCustomSelectedMsg{})
+	m, _ = updateInstall(m, InstallImageSubmitMsg{
+		ImageRef:         "registry.example.com/app:latest",
+		RegistryUsername: "user",
+		RegistryPassword: "pass",
+	})
+
+	expected := docker.RegistrySettings{Image: "registry.example.com/app:latest", Username: "user", Password: "pass"}
+	assert.Equal(t, expected, m.registry)
+
+	m, _ = updateInstall(m, InstallFormSubmitMsg{ImageRef: "registry.example.com/app:latest", Hostname: "app.example.com"})
+	assert.Equal(t, expected, m.activity.registry)
+
+	// Choosing a built-in app afterwards clears the credentials
+	m, _ = updateInstall(m, InstallAppSelectedMsg{ImageRef: "ghcr.io/basecamp/once-campfire"})
+	assert.True(t, m.registry.Empty())
+}
+
+func TestInstall_CustomImageWithoutCredentialsLeavesRegistryEmpty(t *testing.T) {
+	m := newTestInstall()
+	m, _ = updateInstall(m, tea.WindowSizeMsg{Width: 80, Height: 24})
+
+	m, _ = updateInstall(m, InstallCustomSelectedMsg{})
+	m, _ = updateInstall(m, InstallImageSubmitMsg{ImageRef: "ghcr.io/basecamp/once-campfire:latest"})
+	assert.True(t, m.registry.Empty())
+}
+
 func TestInstall_CLIModeSkipsToHostname(t *testing.T) {
 	m := NewInstall(newTestNamespace(), "campfire")
 	assert.Equal(t, installStateHostname, m.state)

--- a/internal/ui/install_test.go
+++ b/internal/ui/install_test.go
@@ -75,6 +75,27 @@ func TestInstall_CustomImageWithoutCredentialsLeavesRegistryEmpty(t *testing.T) 
 	assert.True(t, m.registry.Empty())
 }
 
+func TestInstall_PartialRegistryCredentialsStayOnImageForm(t *testing.T) {
+	m := newTestInstall()
+	m, _ = updateInstall(m, tea.WindowSizeMsg{Width: 80, Height: 24})
+	m, _ = updateInstall(m, InstallCustomSelectedMsg{})
+
+	m, _ = updateInstall(m, InstallImageSubmitMsg{
+		ImageRef:         "registry.example.com/app:latest",
+		RegistryUsername: "user",
+	})
+	assert.Equal(t, installStateImageForm, m.state)
+	assert.ErrorIs(t, m.err, docker.ErrRegistryUsernameWithoutPassword)
+
+	m.err = nil
+	m, _ = updateInstall(m, InstallImageSubmitMsg{
+		ImageRef:         "registry.example.com/app:latest",
+		RegistryPassword: "pass",
+	})
+	assert.Equal(t, installStateImageForm, m.state)
+	assert.ErrorIs(t, m.err, docker.ErrRegistryPasswordWithoutUsername)
+}
+
 func TestInstall_CLIModeSkipsToHostname(t *testing.T) {
 	m := NewInstall(newTestNamespace(), "campfire")
 	assert.Equal(t, installStateHostname, m.state)

--- a/internal/ui/install_test.go
+++ b/internal/ui/install_test.go
@@ -297,6 +297,25 @@ func TestInstall_PullFailureReturnsToImageForm(t *testing.T) {
 	m, _ = updateInstall(m, InstallActivityFailedMsg{Err: pullErr})
 	assert.Equal(t, installStateImageForm, m.state)
 	assert.Equal(t, pullErr, m.err)
+	assert.False(t, m.imageForm.ShowsCredentials(), "a plain pull failure keeps the credential fields hidden")
+}
+
+func TestInstall_AuthLikePullFailureRevealsCredentialFields(t *testing.T) {
+	ns := newTestNamespace()
+	m := NewInstall(ns, "")
+	m, _ = updateInstall(m, tea.WindowSizeMsg{Width: 80, Height: 24})
+	m, _ = updateInstall(m, InstallCustomSelectedMsg{})
+	m, _ = updateInstall(m, InstallImageSubmitMsg{ImageRef: "registry.example.com/app:latest"})
+	m, _ = updateInstall(m, InstallFormSubmitMsg{ImageRef: "registry.example.com/app:latest", Hostname: "app.example.com"})
+	assert.Equal(t, installStateActivity, m.state)
+	assert.False(t, m.imageForm.ShowsCredentials())
+
+	pullErr := fmt.Errorf("%w: %w: %w", docker.ErrDeployFailed, docker.ErrPullMaybeUnauthorized, docker.ErrPullFailed)
+	m, _ = updateInstall(m, InstallActivityFailedMsg{Err: pullErr})
+	assert.Equal(t, installStateImageForm, m.state)
+	assert.True(t, m.imageForm.ShowsCredentials())
+	assert.Equal(t, "registry.example.com/app:latest", m.imageForm.ImageRef(), "typed image ref is preserved")
+	assert.Equal(t, pullErr, m.err)
 }
 
 func TestInstall_PullFailureReturnsToAppList(t *testing.T) {

--- a/internal/ui/settings.go
+++ b/internal/ui/settings.go
@@ -245,6 +245,10 @@ func (m Settings) handleFormSubmit(msg SettingsSectionSubmitMsg) (Component, tea
 	if msg.Settings.Equal(m.app.Settings) {
 		return m, m.navigateToDashboard()
 	}
+	if err := msg.Settings.Validate(); err != nil {
+		m.err = err
+		return m, nil
+	}
 	if m.namespace.HostInUseByAnother(msg.Settings.Host, m.app.Settings.Name) {
 		m.err = docker.ErrHostnameInUse
 		return m, nil

--- a/internal/ui/settings.go
+++ b/internal/ui/settings.go
@@ -56,6 +56,7 @@ type Settings struct {
 	progress             Progress
 	err                  error
 	actionSuccessMessage string
+	savedSettings        docker.ApplicationSettings
 }
 
 type settingsDeployFinishedMsg struct {
@@ -174,6 +175,12 @@ func (m Settings) Update(msg tea.Msg) (Component, tea.Cmd) {
 		})
 
 	case settingsDeployFinishedMsg:
+		if msg.err != nil {
+			m.app.Settings = m.savedSettings
+			m.state = settingsStateForm
+			m.err = msg.err
+			return m, nil
+		}
 		return m, func() tea.Msg { return NavigateToAppMsg{App: m.app} }
 
 	case settingsActionFinishedMsg:
@@ -254,6 +261,7 @@ func (m Settings) handleFormSubmit(msg SettingsSectionSubmitMsg) (Component, tea
 		return m, nil
 	}
 	m.state = settingsStateDeploying
+	m.savedSettings = m.app.Settings
 	m.app.Settings = msg.Settings
 	m.progress = NewProgress(m.width, Colors.Border)
 	return m, tea.Batch(m.progress.Init(), m.runDeploy())

--- a/internal/ui/settings.go
+++ b/internal/ui/settings.go
@@ -82,6 +82,8 @@ func NewSettings(ns *docker.Namespace, app *docker.Application, sectionType Sett
 	switch sectionType {
 	case SettingsSectionApplication:
 		section = NewSettingsFormApplication(app.Settings)
+	case SettingsSectionRegistry:
+		section = NewSettingsFormRegistry(app.Settings)
 	case SettingsSectionEmail:
 		section = NewSettingsFormEmail(app.Settings)
 	case SettingsSectionEnvironment:

--- a/internal/ui/settings_form_application.go
+++ b/internal/ui/settings_form_application.go
@@ -8,8 +8,6 @@ import (
 
 const (
 	appImageField = iota
-	appRegistryUsernameField
-	appRegistryPasswordField
 	appHostnameField
 	appTLSField
 )
@@ -21,13 +19,6 @@ type SettingsFormApplication struct {
 func NewSettingsFormApplication(settings docker.ApplicationSettings) SettingsFormApplication {
 	imageField := NewTextField("user/repo:tag")
 	imageField.SetValue(settings.Image)
-
-	registryUsernameField := NewTextField("(optional)")
-	registryUsernameField.SetValue(settings.Registry.Username)
-
-	registryPasswordField := NewTextField("(optional)")
-	registryPasswordField.SetEchoPassword()
-	registryPasswordField.SetValue(settings.Registry.Password)
 
 	hostnameField := NewTextField("app.example.com")
 	hostnameField.SetValue(settings.Host)
@@ -45,8 +36,6 @@ func NewSettingsFormApplication(settings docker.ApplicationSettings) SettingsFor
 			title: "Application",
 			form: NewForm("Done",
 				FormItem{Label: "Image", Field: imageField, Required: true},
-				FormItem{Label: "Registry Username", Field: registryUsernameField},
-				FormItem{Label: "Registry Password", Field: registryPasswordField},
 				FormItem{Label: "Hostname", Field: hostnameField, Required: true},
 				FormItem{Label: "TLS", Field: tlsField},
 			),
@@ -58,16 +47,6 @@ func NewSettingsFormApplication(settings docker.ApplicationSettings) SettingsFor
 		s.Image = f.TextField(appImageField).Value()
 		s.Host = f.TextField(appHostnameField).Value()
 		s.DisableTLS = !f.CheckboxField(appTLSField).Checked()
-
-		username := f.TextField(appRegistryUsernameField).Value()
-		password := f.TextField(appRegistryPasswordField).Value()
-		if username != settings.Registry.Username || password != settings.Registry.Password {
-			s.Registry = docker.RegistrySettings{Image: s.Image, Username: username, Password: password}
-			if username == "" && password == "" {
-				s.Registry = docker.RegistrySettings{}
-			}
-		}
-
 		return func() tea.Msg { return SettingsSectionSubmitMsg{Settings: s} }
 	})
 	m.form.OnCancel(func(f *Form) tea.Cmd {

--- a/internal/ui/settings_form_application.go
+++ b/internal/ui/settings_form_application.go
@@ -8,6 +8,8 @@ import (
 
 const (
 	appImageField = iota
+	appRegistryUsernameField
+	appRegistryPasswordField
 	appHostnameField
 	appTLSField
 )
@@ -19,6 +21,13 @@ type SettingsFormApplication struct {
 func NewSettingsFormApplication(settings docker.ApplicationSettings) SettingsFormApplication {
 	imageField := NewTextField("user/repo:tag")
 	imageField.SetValue(settings.Image)
+
+	registryUsernameField := NewTextField("(optional)")
+	registryUsernameField.SetValue(settings.Registry.Username)
+
+	registryPasswordField := NewTextField("(optional)")
+	registryPasswordField.SetEchoPassword()
+	registryPasswordField.SetValue(settings.Registry.Password)
 
 	hostnameField := NewTextField("app.example.com")
 	hostnameField.SetValue(settings.Host)
@@ -36,6 +45,8 @@ func NewSettingsFormApplication(settings docker.ApplicationSettings) SettingsFor
 			title: "Application",
 			form: NewForm("Done",
 				FormItem{Label: "Image", Field: imageField, Required: true},
+				FormItem{Label: "Registry Username", Field: registryUsernameField},
+				FormItem{Label: "Registry Password", Field: registryPasswordField},
 				FormItem{Label: "Hostname", Field: hostnameField, Required: true},
 				FormItem{Label: "TLS", Field: tlsField},
 			),
@@ -47,6 +58,16 @@ func NewSettingsFormApplication(settings docker.ApplicationSettings) SettingsFor
 		s.Image = f.TextField(appImageField).Value()
 		s.Host = f.TextField(appHostnameField).Value()
 		s.DisableTLS = !f.CheckboxField(appTLSField).Checked()
+
+		username := f.TextField(appRegistryUsernameField).Value()
+		password := f.TextField(appRegistryPasswordField).Value()
+		if username != settings.Registry.Username || password != settings.Registry.Password {
+			s.Registry = docker.RegistrySettings{Image: s.Image, Username: username, Password: password}
+			if username == "" && password == "" {
+				s.Registry = docker.RegistrySettings{}
+			}
+		}
+
 		return func() tea.Msg { return SettingsSectionSubmitMsg{Settings: s} }
 	})
 	m.form.OnCancel(func(f *Form) tea.Cmd {

--- a/internal/ui/settings_form_registry.go
+++ b/internal/ui/settings_form_registry.go
@@ -1,0 +1,68 @@
+package ui
+
+import (
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/basecamp/once/internal/docker"
+)
+
+const (
+	registryUsernameField = iota
+	registryPasswordField
+)
+
+type SettingsFormRegistry struct {
+	settingsFormBase
+}
+
+func NewSettingsFormRegistry(settings docker.ApplicationSettings) SettingsFormRegistry {
+	host, _ := docker.RegistryHost(settings.Image)
+
+	usernameField := NewTextField("(optional)")
+	passwordField := NewTextField("(optional)")
+	passwordField.SetEchoPassword()
+
+	if settings.Registry.Host == host {
+		usernameField.SetValue(settings.Registry.Username)
+		passwordField.SetValue(settings.Registry.Password)
+	}
+
+	m := SettingsFormRegistry{
+		settingsFormBase: settingsFormBase{
+			title: "Registry",
+			form: NewForm("Done",
+				FormItem{Label: "Registry Username", Field: usernameField},
+				FormItem{Label: "Registry Password", Field: passwordField},
+			),
+			statusLine: func() string {
+				if host == "" {
+					return ""
+				}
+				return "Credentials for " + host
+			},
+		},
+	}
+
+	m.form.OnSubmit(func(f *Form) tea.Cmd {
+		s := settings
+		username := f.TextField(registryUsernameField).Value()
+		password := f.TextField(registryPasswordField).Value()
+		if username == "" && password == "" {
+			s.Registry = docker.RegistrySettings{}
+		} else {
+			s.Registry = docker.RegistrySettings{Host: host, Username: username, Password: password}
+		}
+		return func() tea.Msg { return SettingsSectionSubmitMsg{Settings: s} }
+	})
+	m.form.OnCancel(func(f *Form) tea.Cmd {
+		return func() tea.Msg { return SettingsSectionCancelMsg{} }
+	})
+
+	return m
+}
+
+func (m SettingsFormRegistry) Update(msg tea.Msg) (SettingsSection, tea.Cmd) {
+	var cmd tea.Cmd
+	m.settingsFormBase, cmd = m.update(msg)
+	return m, cmd
+}

--- a/internal/ui/settings_form_test.go
+++ b/internal/ui/settings_form_test.go
@@ -41,16 +41,22 @@ func TestSettingsFormApplication_TabNavigation(t *testing.T) {
 	assert.Equal(t, 0, form.form.Focused())
 
 	applicationPressTab(&form)
-	assert.Equal(t, 1, form.form.Focused(), "hostname")
+	assert.Equal(t, 1, form.form.Focused(), "registry username")
 
 	applicationPressTab(&form)
-	assert.Equal(t, 2, form.form.Focused(), "tls")
+	assert.Equal(t, 2, form.form.Focused(), "registry password")
 
 	applicationPressTab(&form)
-	assert.Equal(t, 3, form.form.Focused(), "done button")
+	assert.Equal(t, 3, form.form.Focused(), "hostname")
 
 	applicationPressTab(&form)
-	assert.Equal(t, 4, form.form.Focused(), "cancel button")
+	assert.Equal(t, 4, form.form.Focused(), "tls")
+
+	applicationPressTab(&form)
+	assert.Equal(t, 5, form.form.Focused(), "done button")
+
+	applicationPressTab(&form)
+	assert.Equal(t, 6, form.form.Focused(), "cancel button")
 
 	applicationPressTab(&form)
 	assert.Equal(t, 0, form.form.Focused(), "wraps to image")
@@ -60,19 +66,20 @@ func TestSettingsFormApplication_ShiftTabNavigation(t *testing.T) {
 	form := NewSettingsFormApplication(docker.ApplicationSettings{Host: "app.example.com"})
 
 	applicationPressShiftTab(&form)
-	assert.Equal(t, 4, form.form.Focused(), "cancel button")
+	assert.Equal(t, 6, form.form.Focused(), "cancel button")
 
 	applicationPressShiftTab(&form)
-	assert.Equal(t, 3, form.form.Focused(), "done button")
+	assert.Equal(t, 5, form.form.Focused(), "done button")
 }
 
 func TestSettingsFormApplication_SpaceTogglesTLS(t *testing.T) {
 	form := NewSettingsFormApplication(docker.ApplicationSettings{Host: "app.example.com"})
 	assert.True(t, form.form.CheckboxField(appTLSField).Checked())
 
-	applicationPressTab(&form)
-	applicationPressTab(&form)
-	assert.Equal(t, 2, form.form.Focused())
+	for range 4 {
+		applicationPressTab(&form)
+	}
+	assert.Equal(t, appTLSField, form.form.Focused())
 
 	applicationPressSpace(&form)
 	assert.False(t, form.form.CheckboxField(appTLSField).Checked())
@@ -84,9 +91,10 @@ func TestSettingsFormApplication_SpaceTogglesTLS(t *testing.T) {
 func TestSettingsFormApplication_SpaceDoesNotToggleTLSForLocalhost(t *testing.T) {
 	form := NewSettingsFormApplication(docker.ApplicationSettings{Host: "chat.localhost"})
 
-	applicationPressTab(&form)
-	applicationPressTab(&form)
-	assert.Equal(t, 2, form.form.Focused())
+	for range 4 {
+		applicationPressTab(&form)
+	}
+	assert.Equal(t, appTLSField, form.form.Focused())
 
 	applicationPressSpace(&form)
 	assert.True(t, form.form.CheckboxField(appTLSField).Checked(), "toggle ignored for localhost")
@@ -96,7 +104,9 @@ func TestSettingsFormApplication_TLSShowsDisabledForLocalhost(t *testing.T) {
 	form := NewSettingsFormApplication(docker.ApplicationSettings{Host: "app.example.com"})
 	assert.Equal(t, "[✓] Enabled", form.form.CheckboxField(appTLSField).View())
 
-	applicationPressTab(&form)
+	for range 3 {
+		applicationPressTab(&form)
+	}
 	applicationTypeText(&form, ".localhost")
 	assert.Equal(t, "Not available for localhost", form.form.CheckboxField(appTLSField).View())
 
@@ -111,7 +121,7 @@ func TestSettingsFormApplication_Submit(t *testing.T) {
 		Host:  "app.example.com",
 	})
 
-	for range 3 {
+	for range 5 {
 		applicationPressTab(&form)
 	}
 
@@ -126,12 +136,69 @@ func TestSettingsFormApplication_Submit(t *testing.T) {
 	assert.Equal(t, "ghcr.io/basecamp/once-campfire:latest", submitMsg.Settings.Image)
 	assert.Equal(t, "app.example.com", submitMsg.Settings.Host)
 	assert.False(t, submitMsg.Settings.DisableTLS)
+	assert.True(t, submitMsg.Settings.Registry.Empty())
+}
+
+func TestSettingsFormApplication_RegistryCredentials(t *testing.T) {
+	settings := docker.ApplicationSettings{
+		Name:     "myapp",
+		Image:    "registry.example.com/app:v1",
+		Host:     "app.example.com",
+		Registry: docker.RegistrySettings{Image: "registry.example.com/app:v1", Username: "user", Password: "pass"},
+	}
+
+	submitForm := func(t *testing.T, form SettingsFormApplication) docker.ApplicationSettings {
+		t.Helper()
+		for form.form.Focused() != 5 {
+			applicationPressTab(&form)
+		}
+		result, cmd := form.Update(keyPressMsg("enter"))
+		form = result.(SettingsFormApplication)
+		require.NotNil(t, cmd)
+		submitMsg, ok := cmd().(SettingsSectionSubmitMsg)
+		require.True(t, ok)
+		return submitMsg.Settings
+	}
+
+	t.Run("shows existing credentials", func(t *testing.T) {
+		form := NewSettingsFormApplication(settings)
+		assert.Equal(t, "user", form.form.TextField(appRegistryUsernameField).Value())
+		assert.Equal(t, "pass", form.form.TextField(appRegistryPasswordField).Value())
+	})
+
+	t.Run("unchanged credentials keep the existing scope", func(t *testing.T) {
+		form := NewSettingsFormApplication(settings)
+		form.form.TextField(appImageField).SetValue("other.example.com/app:v1")
+
+		result := submitForm(t, form)
+		assert.Equal(t, "other.example.com/app:v1", result.Image)
+		assert.Equal(t, settings.Registry, result.Registry, "scope stays on the old image")
+	})
+
+	t.Run("edited credentials re-scope to the new image", func(t *testing.T) {
+		form := NewSettingsFormApplication(settings)
+		form.form.TextField(appImageField).SetValue("other.example.com/app:v1")
+		form.form.TextField(appRegistryUsernameField).SetValue("newuser")
+
+		result := submitForm(t, form)
+		expected := docker.RegistrySettings{Image: "other.example.com/app:v1", Username: "newuser", Password: "pass"}
+		assert.Equal(t, expected, result.Registry)
+	})
+
+	t.Run("clearing both fields removes the credentials", func(t *testing.T) {
+		form := NewSettingsFormApplication(settings)
+		form.form.TextField(appRegistryUsernameField).SetValue("")
+		form.form.TextField(appRegistryPasswordField).SetValue("")
+
+		result := submitForm(t, form)
+		assert.True(t, result.Registry.Empty())
+	})
 }
 
 func TestSettingsFormApplication_Cancel(t *testing.T) {
 	form := NewSettingsFormApplication(docker.ApplicationSettings{Host: "app.example.com"})
 
-	for range 4 {
+	for range 6 {
 		applicationPressTab(&form)
 	}
 

--- a/internal/ui/settings_form_test.go
+++ b/internal/ui/settings_form_test.go
@@ -41,22 +41,16 @@ func TestSettingsFormApplication_TabNavigation(t *testing.T) {
 	assert.Equal(t, 0, form.form.Focused())
 
 	applicationPressTab(&form)
-	assert.Equal(t, 1, form.form.Focused(), "registry username")
+	assert.Equal(t, 1, form.form.Focused(), "hostname")
 
 	applicationPressTab(&form)
-	assert.Equal(t, 2, form.form.Focused(), "registry password")
+	assert.Equal(t, 2, form.form.Focused(), "tls")
 
 	applicationPressTab(&form)
-	assert.Equal(t, 3, form.form.Focused(), "hostname")
+	assert.Equal(t, 3, form.form.Focused(), "done button")
 
 	applicationPressTab(&form)
-	assert.Equal(t, 4, form.form.Focused(), "tls")
-
-	applicationPressTab(&form)
-	assert.Equal(t, 5, form.form.Focused(), "done button")
-
-	applicationPressTab(&form)
-	assert.Equal(t, 6, form.form.Focused(), "cancel button")
+	assert.Equal(t, 4, form.form.Focused(), "cancel button")
 
 	applicationPressTab(&form)
 	assert.Equal(t, 0, form.form.Focused(), "wraps to image")
@@ -66,20 +60,19 @@ func TestSettingsFormApplication_ShiftTabNavigation(t *testing.T) {
 	form := NewSettingsFormApplication(docker.ApplicationSettings{Host: "app.example.com"})
 
 	applicationPressShiftTab(&form)
-	assert.Equal(t, 6, form.form.Focused(), "cancel button")
+	assert.Equal(t, 4, form.form.Focused(), "cancel button")
 
 	applicationPressShiftTab(&form)
-	assert.Equal(t, 5, form.form.Focused(), "done button")
+	assert.Equal(t, 3, form.form.Focused(), "done button")
 }
 
 func TestSettingsFormApplication_SpaceTogglesTLS(t *testing.T) {
 	form := NewSettingsFormApplication(docker.ApplicationSettings{Host: "app.example.com"})
 	assert.True(t, form.form.CheckboxField(appTLSField).Checked())
 
-	for range 4 {
-		applicationPressTab(&form)
-	}
-	assert.Equal(t, appTLSField, form.form.Focused())
+	applicationPressTab(&form)
+	applicationPressTab(&form)
+	assert.Equal(t, 2, form.form.Focused())
 
 	applicationPressSpace(&form)
 	assert.False(t, form.form.CheckboxField(appTLSField).Checked())
@@ -91,10 +84,9 @@ func TestSettingsFormApplication_SpaceTogglesTLS(t *testing.T) {
 func TestSettingsFormApplication_SpaceDoesNotToggleTLSForLocalhost(t *testing.T) {
 	form := NewSettingsFormApplication(docker.ApplicationSettings{Host: "chat.localhost"})
 
-	for range 4 {
-		applicationPressTab(&form)
-	}
-	assert.Equal(t, appTLSField, form.form.Focused())
+	applicationPressTab(&form)
+	applicationPressTab(&form)
+	assert.Equal(t, 2, form.form.Focused())
 
 	applicationPressSpace(&form)
 	assert.True(t, form.form.CheckboxField(appTLSField).Checked(), "toggle ignored for localhost")
@@ -104,9 +96,7 @@ func TestSettingsFormApplication_TLSShowsDisabledForLocalhost(t *testing.T) {
 	form := NewSettingsFormApplication(docker.ApplicationSettings{Host: "app.example.com"})
 	assert.Equal(t, "[✓] Enabled", form.form.CheckboxField(appTLSField).View())
 
-	for range 3 {
-		applicationPressTab(&form)
-	}
+	applicationPressTab(&form)
 	applicationTypeText(&form, ".localhost")
 	assert.Equal(t, "Not available for localhost", form.form.CheckboxField(appTLSField).View())
 
@@ -121,7 +111,7 @@ func TestSettingsFormApplication_Submit(t *testing.T) {
 		Host:  "app.example.com",
 	})
 
-	for range 5 {
+	for range 3 {
 		applicationPressTab(&form)
 	}
 
@@ -136,69 +126,12 @@ func TestSettingsFormApplication_Submit(t *testing.T) {
 	assert.Equal(t, "ghcr.io/basecamp/once-campfire:latest", submitMsg.Settings.Image)
 	assert.Equal(t, "app.example.com", submitMsg.Settings.Host)
 	assert.False(t, submitMsg.Settings.DisableTLS)
-	assert.True(t, submitMsg.Settings.Registry.Empty())
-}
-
-func TestSettingsFormApplication_RegistryCredentials(t *testing.T) {
-	settings := docker.ApplicationSettings{
-		Name:     "myapp",
-		Image:    "registry.example.com/app:v1",
-		Host:     "app.example.com",
-		Registry: docker.RegistrySettings{Image: "registry.example.com/app:v1", Username: "user", Password: "pass"},
-	}
-
-	submitForm := func(t *testing.T, form SettingsFormApplication) docker.ApplicationSettings {
-		t.Helper()
-		for form.form.Focused() != 5 {
-			applicationPressTab(&form)
-		}
-		result, cmd := form.Update(keyPressMsg("enter"))
-		form = result.(SettingsFormApplication)
-		require.NotNil(t, cmd)
-		submitMsg, ok := cmd().(SettingsSectionSubmitMsg)
-		require.True(t, ok)
-		return submitMsg.Settings
-	}
-
-	t.Run("shows existing credentials", func(t *testing.T) {
-		form := NewSettingsFormApplication(settings)
-		assert.Equal(t, "user", form.form.TextField(appRegistryUsernameField).Value())
-		assert.Equal(t, "pass", form.form.TextField(appRegistryPasswordField).Value())
-	})
-
-	t.Run("unchanged credentials keep the existing scope", func(t *testing.T) {
-		form := NewSettingsFormApplication(settings)
-		form.form.TextField(appImageField).SetValue("other.example.com/app:v1")
-
-		result := submitForm(t, form)
-		assert.Equal(t, "other.example.com/app:v1", result.Image)
-		assert.Equal(t, settings.Registry, result.Registry, "scope stays on the old image")
-	})
-
-	t.Run("edited credentials re-scope to the new image", func(t *testing.T) {
-		form := NewSettingsFormApplication(settings)
-		form.form.TextField(appImageField).SetValue("other.example.com/app:v1")
-		form.form.TextField(appRegistryUsernameField).SetValue("newuser")
-
-		result := submitForm(t, form)
-		expected := docker.RegistrySettings{Image: "other.example.com/app:v1", Username: "newuser", Password: "pass"}
-		assert.Equal(t, expected, result.Registry)
-	})
-
-	t.Run("clearing both fields removes the credentials", func(t *testing.T) {
-		form := NewSettingsFormApplication(settings)
-		form.form.TextField(appRegistryUsernameField).SetValue("")
-		form.form.TextField(appRegistryPasswordField).SetValue("")
-
-		result := submitForm(t, form)
-		assert.True(t, result.Registry.Empty())
-	})
 }
 
 func TestSettingsFormApplication_Cancel(t *testing.T) {
 	form := NewSettingsFormApplication(docker.ApplicationSettings{Host: "app.example.com"})
 
-	for range 6 {
+	for range 4 {
 		applicationPressTab(&form)
 	}
 
@@ -290,6 +223,79 @@ func TestSettingsFormEmail_Cancel(t *testing.T) {
 
 	result, cmd := form.Update(keyPressMsg("enter"))
 	form = result.(SettingsFormEmail)
+	require.NotNil(t, cmd)
+	msg := cmd()
+	_, ok := msg.(SettingsSectionCancelMsg)
+	assert.True(t, ok, "expected SettingsSectionCancelMsg, got %T", msg)
+}
+
+func TestSettingsFormRegistry_Submit(t *testing.T) {
+	settings := docker.ApplicationSettings{
+		Name:     "myapp",
+		Image:    "ghcr.io/basecamp/app:v1",
+		Registry: docker.RegistrySettings{Host: "ghcr.io", Username: "user", Password: "pass"},
+	}
+
+	submitForm := func(t *testing.T, form SettingsFormRegistry) docker.ApplicationSettings {
+		t.Helper()
+		for form.form.Focused() != 2 {
+			registryPressTab(&form)
+		}
+		result, cmd := form.Update(keyPressMsg("enter"))
+		form = result.(SettingsFormRegistry)
+		require.NotNil(t, cmd)
+		submitMsg, ok := cmd().(SettingsSectionSubmitMsg)
+		require.True(t, ok)
+		return submitMsg.Settings
+	}
+
+	t.Run("shows credentials for the image's host", func(t *testing.T) {
+		form := NewSettingsFormRegistry(settings)
+		assert.Equal(t, "user", form.form.TextField(registryUsernameField).Value())
+		assert.Equal(t, "pass", form.form.TextField(registryPasswordField).Value())
+		assert.Equal(t, "Credentials for ghcr.io", form.StatusLine())
+	})
+
+	t.Run("starts empty when the stored host differs", func(t *testing.T) {
+		s := settings
+		s.Image = "registry.example.com/app:v1"
+		form := NewSettingsFormRegistry(s)
+		assert.Empty(t, form.form.TextField(registryUsernameField).Value())
+		assert.Empty(t, form.form.TextField(registryPasswordField).Value())
+		assert.Equal(t, "Credentials for registry.example.com", form.StatusLine())
+	})
+
+	t.Run("submit scopes credentials to the image's host", func(t *testing.T) {
+		s := settings
+		s.Image = "registry.example.com/app:v1"
+		form := NewSettingsFormRegistry(s)
+		form.form.TextField(registryUsernameField).SetValue("newuser")
+		form.form.TextField(registryPasswordField).SetValue("newpass")
+
+		result := submitForm(t, form)
+		expected := docker.RegistrySettings{Host: "registry.example.com", Username: "newuser", Password: "newpass"}
+		assert.Equal(t, expected, result.Registry)
+	})
+
+	t.Run("submit with empty fields clears the credentials", func(t *testing.T) {
+		form := NewSettingsFormRegistry(settings)
+		form.form.TextField(registryUsernameField).SetValue("")
+		form.form.TextField(registryPasswordField).SetValue("")
+
+		result := submitForm(t, form)
+		assert.True(t, result.Registry.Empty())
+	})
+}
+
+func TestSettingsFormRegistry_Cancel(t *testing.T) {
+	form := NewSettingsFormRegistry(docker.ApplicationSettings{Image: "ghcr.io/basecamp/app:v1"})
+
+	for range 3 {
+		registryPressTab(&form)
+	}
+
+	result, cmd := form.Update(keyPressMsg("enter"))
+	form = result.(SettingsFormRegistry)
 	require.NotNil(t, cmd)
 	msg := cmd()
 	_, ok := msg.(SettingsSectionCancelMsg)
@@ -480,6 +486,10 @@ func applicationPressSpace(form *SettingsFormApplication) {
 }
 
 func emailPressTab(form *SettingsFormEmail) {
+	updateSettingsForm(form, keyPressMsg("tab"))
+}
+
+func registryPressTab(form *SettingsFormRegistry) {
 	updateSettingsForm(form, keyPressMsg("tab"))
 }
 

--- a/internal/ui/settings_menu.go
+++ b/internal/ui/settings_menu.go
@@ -30,6 +30,7 @@ func NewSettingsMenu(app *docker.Application) SettingsMenu {
 		app: app,
 		menu: NewMenu(
 			MenuItem{Label: "Application", Key: int(SettingsSectionApplication), Shortcut: WithHelp(NewKeyBinding("a"), "a", "")},
+			MenuItem{Label: "Registry", Key: int(SettingsSectionRegistry), Shortcut: WithHelp(NewKeyBinding("g"), "g", "")},
 			MenuItem{Label: "Email", Key: int(SettingsSectionEmail), Shortcut: WithHelp(NewKeyBinding("e"), "e", "")},
 			MenuItem{Label: "Environment", Key: int(SettingsSectionEnvironment), Shortcut: WithHelp(NewKeyBinding("v"), "v", "")},
 			MenuItem{Label: "Resources", Key: int(SettingsSectionResources), Shortcut: WithHelp(NewKeyBinding("r"), "r", "")},

--- a/internal/ui/settings_test.go
+++ b/internal/ui/settings_test.go
@@ -59,6 +59,17 @@ func TestSettings_SubmitChangedStartsDeploy(t *testing.T) {
 	assert.Equal(t, settingsStateDeploying, s.state)
 }
 
+func TestSettings_SubmitInvalidSettingsStaysOnForm(t *testing.T) {
+	s := testSettings()
+
+	changed := s.app.Settings
+	changed.Registry = docker.RegistrySettings{Host: "ghcr.io", Username: "user"}
+
+	s, _ = updateSettings(s, SettingsSectionSubmitMsg{Settings: changed})
+	assert.Equal(t, settingsStateForm, s.state)
+	assert.ErrorIs(t, s.err, docker.ErrRegistryUsernameWithoutPassword)
+}
+
 func TestSettings_DeployFinishedNavigatesToApp(t *testing.T) {
 	s := testSettings()
 	s.state = settingsStateDeploying

--- a/internal/ui/settings_test.go
+++ b/internal/ui/settings_test.go
@@ -82,18 +82,21 @@ func TestSettings_DeployFinishedNavigatesToApp(t *testing.T) {
 	assert.True(t, ok)
 }
 
-func TestSettings_DeployFinishedWithErrorStillNavigates(t *testing.T) {
-	// Current behavior: deploy errors are not surfaced to the user;
-	// the handler always navigates to the app screen.
+func TestSettings_DeployFailureReturnsToFormAndRestoresSettings(t *testing.T) {
 	s := testSettings()
-	s.state = settingsStateDeploying
+	original := s.app.Settings
 
-	_, cmd := updateSettings(s, settingsDeployFinishedMsg{err: assert.AnError})
-	require.NotNil(t, cmd)
+	changed := original
+	changed.Image = "registry.example.com/missing:latest"
+	s, _ = updateSettings(s, SettingsSectionSubmitMsg{Settings: changed})
+	assert.Equal(t, settingsStateDeploying, s.state)
+	assert.Equal(t, changed, s.app.Settings)
 
-	msg := cmd()
-	_, ok := msg.(NavigateToAppMsg)
-	assert.True(t, ok)
+	s, cmd := updateSettings(s, settingsDeployFinishedMsg{err: assert.AnError})
+	assert.Nil(t, cmd)
+	assert.Equal(t, settingsStateForm, s.state)
+	assert.ErrorIs(t, s.err, assert.AnError)
+	assert.Equal(t, original, s.app.Settings, "failed deploy restores the saved settings")
 }
 
 func TestSettings_ActionFinishedWithError(t *testing.T) {


### PR DESCRIPTION
Provides a way to manage registry credentials for each application.

- Application config can contain registry credentials. When supplied, they are used for the `docker pull`. (When not supplied, we fall back to the previous behaviour)
- CLI deploy/update commands allow specifying `--registry-username`/`--registry-password`. Also allow `--registry-password-stdin` to read from stdin and avoid leaking into shell history
- TUI adds a new "Registry" panel to the application settings, where the credentials can be set. Also, when a new custom application deployment fails to pull, we reveal credential fields on the image screen so they can be entered

Saved credentials are scoped to the host of the imageRef, to avoid leaking them to another host if the image is changed.