### PR TITLE
Update to Go 1.27

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/basecamp/once
 
-go 1.26.7
+go 1.27.0
 
 require (
 	charm.land/bubbles/v2 v2.2.1

--- a/integration/docker_test.go
+++ b/integration/docker_test.go
@@ -174,7 +174,7 @@ func TestApplicationVolume(t *testing.T) {
 
 	ns := newTestNamespace(t, "once-volume-label-test")
 
-	vol1, err := docker.CreateVolume(ctx, ns, "testapp", docker.ApplicationLegacyVolumeSettings{Keys: docker.Keys{SecretKeyBase: "test-secret"}})
+	vol1, err := docker.CreateVolume(ctx, ns, "testapp", docker.ApplicationLegacyVolumeSettings{SecretKeyBase: "test-secret"})
 	require.NoError(t, err)
 	assert.Equal(t, "test-secret", vol1.Settings.SecretKeyBase)
 
@@ -1436,7 +1436,7 @@ func buildTestBackup(t *testing.T, imageName string) []byte {
 		Image: imageName,
 		Host:  "hookapp.localhost",
 	}
-	volSettings := docker.ApplicationLegacyVolumeSettings{Keys: docker.Keys{SecretKeyBase: "test-secret-key"}}
+	volSettings := docker.ApplicationLegacyVolumeSettings{SecretKeyBase: "test-secret-key"}
 
 	var buf bytes.Buffer
 	gw := gzip.NewWriter(&buf)

--- a/internal/docker/volume_test.go
+++ b/internal/docker/volume_test.go
@@ -9,11 +9,9 @@ import (
 
 func TestVolumeSettingsMarshalRoundTrip(t *testing.T) {
 	original := ApplicationLegacyVolumeSettings{
-		Keys: Keys{
-			SecretKeyBase:   "secret",
-			VAPIDPublicKey:  "pub123",
-			VAPIDPrivateKey: "priv456",
-		},
+		SecretKeyBase:   "secret",
+		VAPIDPublicKey:  "pub123",
+		VAPIDPrivateKey: "priv456",
 	}
 
 	restored, err := UnmarshalApplicationLegacyVolumeSettings(original.Marshal())

--- a/internal/ui/settings_form_application.go
+++ b/internal/ui/settings_form_application.go
@@ -32,14 +32,12 @@ func NewSettingsFormApplication(settings docker.ApplicationSettings) SettingsFor
 	})
 
 	m := SettingsFormApplication{
-		settingsFormBase: settingsFormBase{
-			title: "Application",
-			form: NewForm("Done",
-				FormItem{Label: "Image", Field: imageField, Required: true},
-				FormItem{Label: "Hostname", Field: hostnameField, Required: true},
-				FormItem{Label: "TLS", Field: tlsField},
-			),
-		},
+		title: "Application",
+		form: NewForm("Done",
+			FormItem{Label: "Image", Field: imageField, Required: true},
+			FormItem{Label: "Hostname", Field: hostnameField, Required: true},
+			FormItem{Label: "TLS", Field: tlsField},
+		),
 	}
 
 	m.form.OnSubmit(func(f *Form) tea.Cmd {

--- a/internal/ui/settings_form_backups.go
+++ b/internal/ui/settings_form_backups.go
@@ -24,17 +24,14 @@ func NewSettingsFormBackups(app *docker.Application, lastResult *docker.Operatio
 	autoBackupField := NewCheckboxField("Automatically create backups", app.Settings.Backup.AutoBackup)
 
 	m := SettingsFormBackups{
-		settingsFormBase: settingsFormBase{
-			title: "Backups",
-			form: NewForm("Done",
-				FormItem{Label: "Backup location", Field: pathField},
-				FormItem{Label: "Backups", Field: autoBackupField},
-			),
+		title: "Backups",
+		form: NewForm("Done",
+			FormItem{Label: "Backup location", Field: pathField},
+			FormItem{Label: "Backups", Field: autoBackupField},
+		),
+		statusLine: func() string {
+			return formatOperationStatus("backup", lastResult)
 		},
-	}
-
-	m.statusLine = func() string {
-		return formatOperationStatus("backup", lastResult)
 	}
 
 	m.form.SetActionButton("Run backup now", func() tea.Msg {

--- a/internal/ui/settings_form_email.go
+++ b/internal/ui/settings_form_email.go
@@ -37,16 +37,14 @@ func NewSettingsFormEmail(settings docker.ApplicationSettings) SettingsFormEmail
 	fromField.SetValue(settings.SMTP.From)
 
 	m := SettingsFormEmail{
-		settingsFormBase: settingsFormBase{
-			title: "Email",
-			form: NewForm("Done",
-				FormItem{Label: "SMTP Server", Field: serverField},
-				FormItem{Label: "SMTP Port", Field: portField},
-				FormItem{Label: "SMTP Username", Field: usernameField},
-				FormItem{Label: "SMTP Password", Field: passwordField},
-				FormItem{Label: "SMTP From", Field: fromField},
-			),
-		},
+		title: "Email",
+		form: NewForm("Done",
+			FormItem{Label: "SMTP Server", Field: serverField},
+			FormItem{Label: "SMTP Port", Field: portField},
+			FormItem{Label: "SMTP Username", Field: usernameField},
+			FormItem{Label: "SMTP Password", Field: passwordField},
+			FormItem{Label: "SMTP From", Field: fromField},
+		),
 	}
 
 	m.form.OnSubmit(func(f *Form) tea.Cmd {

--- a/internal/ui/settings_form_environment.go
+++ b/internal/ui/settings_form_environment.go
@@ -30,10 +30,8 @@ func NewSettingsFormEnvironment(settings docker.ApplicationSettings) SettingsFor
 	items = append(items, newEnvKeyItem(""), newEnvValueItem(""))
 
 	m := SettingsFormEnvironment{
-		settingsFormBase: settingsFormBase{
-			title: "Environment",
-			form:  NewForm("Done", items...),
-		},
+		title:    "Environment",
+		form:     NewForm("Done", items...),
 		settings: settings,
 	}
 

--- a/internal/ui/settings_form_registry.go
+++ b/internal/ui/settings_form_registry.go
@@ -28,18 +28,16 @@ func NewSettingsFormRegistry(settings docker.ApplicationSettings) SettingsFormRe
 	}
 
 	m := SettingsFormRegistry{
-		settingsFormBase: settingsFormBase{
-			title: "Registry",
-			form: NewForm("Done",
-				FormItem{Label: "Registry Username", Field: usernameField},
-				FormItem{Label: "Registry Password", Field: passwordField},
-			),
-			statusLine: func() string {
-				if host == "" {
-					return ""
-				}
-				return "Credentials for " + host
-			},
+		title: "Registry",
+		form: NewForm("Done",
+			FormItem{Label: "Registry Username", Field: usernameField},
+			FormItem{Label: "Registry Password", Field: passwordField},
+		),
+		statusLine: func() string {
+			if host == "" {
+				return ""
+			}
+			return "Credentials for " + host
 		},
 	}
 

--- a/internal/ui/settings_form_resources.go
+++ b/internal/ui/settings_form_resources.go
@@ -33,13 +33,11 @@ func NewSettingsFormResources(settings docker.ApplicationSettings) SettingsFormR
 	}
 
 	m := SettingsFormResources{
-		settingsFormBase: settingsFormBase{
-			title: "Resources",
-			form: NewForm("Done",
-				FormItem{Label: "CPU Limit", Field: cpuField},
-				FormItem{Label: "Memory Limit (MB)", Field: memoryField},
-			),
-		},
+		title: "Resources",
+		form: NewForm("Done",
+			FormItem{Label: "CPU Limit", Field: cpuField},
+			FormItem{Label: "Memory Limit (MB)", Field: memoryField},
+		),
 	}
 
 	m.form.OnSubmit(func(f *Form) tea.Cmd {

--- a/internal/ui/settings_form_updates.go
+++ b/internal/ui/settings_form_updates.go
@@ -18,16 +18,13 @@ func NewSettingsFormUpdates(app *docker.Application, lastResult *docker.Operatio
 	autoUpdateField := NewCheckboxField("Automatically apply updates", app.Settings.AutoUpdate)
 
 	m := SettingsFormUpdates{
-		settingsFormBase: settingsFormBase{
-			title: "Updates",
-			form: NewForm("Done",
-				FormItem{Label: "Updates", Field: autoUpdateField},
-			),
+		title: "Updates",
+		form: NewForm("Done",
+			FormItem{Label: "Updates", Field: autoUpdateField},
+		),
+		statusLine: func() string {
+			return formatOperationStatus("checked", lastResult)
 		},
-	}
-
-	m.statusLine = func() string {
-		return formatOperationStatus("checked", lastResult)
 	}
 
 	m.form.SetActionButton("Check for updates", func() tea.Msg {


### PR DESCRIPTION
Updates the toolchain to Go 1.27.0. CI reads the version from go.mod, so no workflow changes are needed.

Also applies the Go 1.27 `go fix` modernizations. The new `embedlit` fixer rewrites embedded-struct literals to use the new field-selector syntax in struct literals. Two of the rewritten sites were reformatted by hand for readability.